### PR TITLE
TCP Support

### DIFF
--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -47,5 +47,9 @@ radius_retries	3
 # local address from which radius packets have to be sent
 bindaddr *
 
+# Transport Protocol Support
+# Use "1" for using UDP and "2" for TCP protocol.
+radius_proto   1
+
 # To enable verbose debugging messages in syslog, enable the following
 #clientdebug 1

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -419,6 +419,10 @@ enum rc_vendor_attr_roaringpenguin {
 #define PW_AUTH_ONLY		3
 #define PW_ALL			255
 
+/* Transport Protocol Types */
+#define PROTO_TCP  1
+#define PROTO_UDP  2
+
 /* Server data structures */
 
 typedef struct dict_attr
@@ -485,6 +489,7 @@ typedef struct send_data /* Used to pass information to sendserver() function */
 	int            retries;
 	VALUE_PAIR     *send_pairs;     //!< More a/v pairs to send.
 	VALUE_PAIR     *receive_pairs;  //!< Where to place received a/v pairs.
+	uint8_t        radius_proto;    //!< Transport protocol type. 
 } SEND_DATA;
 
 #define AUTH_VECTOR_LEN		16

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -121,7 +121,13 @@ int rc_aaa_ctx_server(rc_handle * rh, RC_AAA_CTX ** ctx, SERVER * aaaserver,
 	double start_time = 0;
 	double now = 0;
 	time_t dtime;
-	int servernum;
+	int servernum, radius_proto = 0;
+
+	radius_proto = rc_conf_int(rh, "radius_proto");
+	if(1 == radius_proto)
+		data.radius_proto = PROTO_UDP;
+	else
+		data.radius_proto = PROTO_TCP;
 
 	data.send_pairs = send;
 	data.receive_pairs = NULL;

--- a/lib/options.h
+++ b/lib/options.h
@@ -45,6 +45,7 @@ static OPTION config_options_default[] = {
 {"radius_retries",	OT_INT,	ST_UNDEF, NULL},
 {"radius_deadtime",	OT_INT, ST_UNDEF, NULL},
 {"bindaddr",		OT_STR, ST_UNDEF, NULL},
+{"radius_proto",	OT_INT, ST_UNDEF, NULL},
 {"clientdebug",		OT_INT, ST_UNDEF, NULL},
 /* Deprecated options */
 {"login_radius",	OT_STR, ST_UNDEF, NULL},

--- a/m4/libtool.m4
+++ b/m4/libtool.m4
@@ -1324,12 +1324,19 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
 	    LD="${LD-ld} -m elf_i386_fbsd"
 	    ;;
 	  x86_64-*linux*)
-	    LD="${LD-ld} -m elf_i386"
+	    case `/usr/bin/file conftest.o` in
+	      *x86-64*)
+		LD="${LD-ld} -m elf32_x86_64"
+		;;
+	      *)
+		LD="${LD-ld} -m elf_i386"
+		;;
+	    esac
 	    ;;
-	  powerpc64le-*linux*)
+	  powerpc64le-*)
 	    LD="${LD-ld} -m elf32lppclinux"
 	    ;;
-	  powerpc64-*linux*)
+	  powerpc64-*)
 	    LD="${LD-ld} -m elf32ppclinux"
 	    ;;
 	  s390x-*linux*)
@@ -1348,10 +1355,10 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
 	  x86_64-*linux*)
 	    LD="${LD-ld} -m elf_x86_64"
 	    ;;
-	  powerpcle-*linux*)
+	  powerpcle-*)
 	    LD="${LD-ld} -m elf64lppc"
 	    ;;
-	  powerpc-*linux*)
+	  powerpc-*)
 	    LD="${LD-ld} -m elf64ppc"
 	    ;;
 	  s390*-*linux*|s390*-*tpf*)
@@ -1694,7 +1701,8 @@ AC_CACHE_VAL([lt_cv_sys_max_cmd_len], [dnl
     ;;
   *)
     lt_cv_sys_max_cmd_len=`(getconf ARG_MAX) 2> /dev/null`
-    if test -n "$lt_cv_sys_max_cmd_len"; then
+    if test -n "$lt_cv_sys_max_cmd_len" && \
+	test undefined != "$lt_cv_sys_max_cmd_len"; then
       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \/ 4`
       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \* 3`
     else
@@ -2518,17 +2526,6 @@ freebsd* | dragonfly*)
   esac
   ;;
 
-gnu*)
-  version_type=linux # correct to gnu/linux during the next big refactor
-  need_lib_prefix=no
-  need_version=no
-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
-  soname_spec='${libname}${release}${shared_ext}$major'
-  shlibpath_var=LD_LIBRARY_PATH
-  shlibpath_overrides_runpath=no
-  hardcode_into_libs=yes
-  ;;
-
 haiku*)
   version_type=linux # correct to gnu/linux during the next big refactor
   need_lib_prefix=no
@@ -2645,7 +2642,7 @@ linux*oldld* | linux*aout* | linux*coff*)
   ;;
 
 # This must be glibc/ELF.
-linux* | k*bsd*-gnu | kopensolaris*-gnu)
+linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   version_type=linux # correct to gnu/linux during the next big refactor
   need_lib_prefix=no
   need_version=no
@@ -2675,14 +2672,10 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu)
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Add ABI-specific directories to the system library path.
-  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
-
   # Append ld.so.conf contents to the search path
   if test -f /etc/ld.so.conf; then
     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \[$]2)); skip = 1; } { if (!skip) print \[$]0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
-    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
-
+    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
   fi
 
   # We used to test for /lib/ld.so.1 and disable shared libraries on
@@ -2692,6 +2685,18 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu)
   # people can always --disable-shared, the test was removed, and we
   # assume the GNU/Linux dynamic linker is in use.
   dynamic_linker='GNU/Linux ld.so'
+  ;;
+
+netbsdelf*-gnu)
+  version_type=linux
+  need_lib_prefix=no
+  need_version=no
+  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+  soname_spec='${libname}${release}${shared_ext}$major'
+  shlibpath_var=LD_LIBRARY_PATH
+  shlibpath_overrides_runpath=no
+  hardcode_into_libs=yes
+  dynamic_linker='NetBSD ld.elf_so'
   ;;
 
 netbsd*)
@@ -3253,10 +3258,6 @@ freebsd* | dragonfly*)
   fi
   ;;
 
-gnu*)
-  lt_cv_deplibs_check_method=pass_all
-  ;;
-
 haiku*)
   lt_cv_deplibs_check_method=pass_all
   ;;
@@ -3295,11 +3296,11 @@ irix5* | irix6* | nonstopux*)
   ;;
 
 # This must be glibc/ELF.
-linux* | k*bsd*-gnu | kopensolaris*-gnu)
+linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   lt_cv_deplibs_check_method=pass_all
   ;;
 
-netbsd*)
+netbsd* | netbsdelf*-gnu)
   if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
     lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
   else
@@ -4047,7 +4048,7 @@ m4_if([$1], [CXX], [
 	    ;;
 	esac
 	;;
-      linux* | k*bsd*-gnu | kopensolaris*-gnu)
+      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
 	case $cc_basename in
 	  KCC*)
 	    # KAI C++ Compiler
@@ -4111,7 +4112,7 @@ m4_if([$1], [CXX], [
 	    ;;
 	esac
 	;;
-      netbsd*)
+      netbsd* | netbsdelf*-gnu)
 	;;
       *qnx* | *nto*)
         # QNX uses GNU C++, but need to define -shared option too, otherwise
@@ -4346,7 +4347,7 @@ m4_if([$1], [CXX], [
       _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
       ;;
 
-    linux* | k*bsd*-gnu | kopensolaris*-gnu)
+    linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
       case $cc_basename in
       # old Intel for x86_64 which still supported -KPIC.
       ecc*)
@@ -4588,6 +4589,9 @@ m4_if([$1], [CXX], [
       ;;
     esac
     ;;
+  linux* | k*bsd*-gnu | gnu*)
+    _LT_TAGVAR(link_all_deplibs, $1)=no
+    ;;
   *)
     _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
     ;;
@@ -4649,6 +4653,9 @@ dnl Note also adjust exclude_expsyms for C++ above.
     ;;
   openbsd*)
     with_gnu_ld=no
+    ;;
+  linux* | k*bsd*-gnu | gnu*)
+    _LT_TAGVAR(link_all_deplibs, $1)=no
     ;;
   esac
 
@@ -4871,7 +4878,7 @@ _LT_EOF
       fi
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
 	wlarc=
@@ -5048,6 +5055,7 @@ _LT_EOF
 	if test "$aix_use_runtimelinking" = yes; then
 	  shared_flag="$shared_flag "'${wl}-G'
 	fi
+	_LT_TAGVAR(link_all_deplibs, $1)=no
       else
 	# not using gcc
 	if test "$host_cpu" = ia64; then
@@ -5352,7 +5360,7 @@ _LT_EOF
       _LT_TAGVAR(link_all_deplibs, $1)=yes
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
       else
@@ -6232,9 +6240,6 @@ if test "$_lt_caught_CXX_error" != yes; then
         _LT_TAGVAR(ld_shlibs, $1)=yes
         ;;
 
-      gnu*)
-        ;;
-
       haiku*)
         _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
         _LT_TAGVAR(link_all_deplibs, $1)=yes
@@ -6396,7 +6401,7 @@ if test "$_lt_caught_CXX_error" != yes; then
         _LT_TAGVAR(inherit_rpath, $1)=yes
         ;;
 
-      linux* | k*bsd*-gnu | kopensolaris*-gnu)
+      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
         case $cc_basename in
           KCC*)
 	    # Kuck and Associates, Inc. (KAI) C++ Compiler

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,13 +7,15 @@ EXTRA_DIST = radiusclient-ipv6.conf servers-ipv6 \
 	radiusclient.conf servers README \
 	dtls/ca.pem dtls/clicert.pem \
 	dtls/clikey.pem dtls/radiusclient-tls.conf \
-	dtls/radsecproxy.conf
+	dtls/radsecproxy.conf \
+	tcp/radiusclient-tcp.conf 
 
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/src -I$(top_builddir)
 LDADD = ../lib/libradcli.la
 
-dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh
-TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh
+dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh \
+					 tcp-tests.sh
+TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh
 check_PROGRAMS =
 
 if ENABLE_GNUTLS

--- a/tests/docker/radius-clients.conf
+++ b/tests/docker/radius-clients.conf
@@ -310,6 +310,150 @@ client localhost2 {
 #	coa_server = coa
 }
 
+client localhost {
+	#  Allowed values are:
+	#	dotted quad (1.2.3.4)
+	#       hostname    (radius.example.com)
+	ipaddr = 0.0.0.0/0
+	proto = tcp
+	#  OR, you can use an IPv6 address, but not both
+	#  at the same time.
+#	ipv6addr = ::	# any.  ::1 == localhost
+
+	#
+	#  A note on DNS:  We STRONGLY recommend using IP addresses
+	#  rather than host names.  Using host names means that the
+	#  server will do DNS lookups when it starts, making it
+	#  dependent on DNS.  i.e. If anything goes wrong with DNS,
+	#  the server won't start!
+	#
+	#  The server also looks up the IP address from DNS once, and
+	#  only once, when it starts.  If the DNS record is later
+	#  updated, the server WILL NOT see that update.
+	#
+
+	#  One client definition can be applied to an entire network.
+	#  e.g. 127/8 should be defined with "ipaddr = 127.0.0.0" and
+	#  "netmask = 8"
+	#
+	#  If not specified, the default netmask is 32 (i.e. /32)
+	#
+	#  We do NOT recommend using anything other than 32.  There
+	#  are usually other, better ways to achieve the same goal.
+	#  Using netmasks of other than 32 can cause security issues.
+	#
+	#  You can specify overlapping networks (127/8 and 127.0/16)
+	#  In that case, the smallest possible network will be used
+	#  as the "best match" for the client.
+	#
+	#  Clients can also be defined dynamically at run time, based
+	#  on any criteria.  e.g. SQL lookups, keying off of NAS-Identifier,
+	#  etc.
+	#  See raddb/sites-available/dynamic-clients for details.
+	#
+
+#	netmask = 32
+
+	#
+	#  The shared secret use to "encrypt" and "sign" packets between
+	#  the NAS and FreeRADIUS.  You MUST change this secret from the
+	#  default, otherwise it's not a secret any more!
+	#
+	#  The secret can be any string, up to 8k characters in length.
+	#
+	#  Control codes can be entered vi octal encoding,
+	#	e.g. "\101\102" == "AB"
+	#  Quotation marks can be entered by escaping them,
+	#	e.g. "foo\"bar"
+	#
+	#  A note on security:  The security of the RADIUS protocol
+	#  depends COMPLETELY on this secret!  We recommend using a
+	#  shared secret that is composed of:
+	#
+	#	upper case letters
+	#	lower case letters
+	#	numbers
+	#
+	#  And is at LEAST 8 characters long, preferably 16 characters in
+	#  length.  The secret MUST be random, and should not be words,
+	#  phrase, or anything else that is recognizable.
+	#
+	#  The default secret below is only for testing, and should
+	#  not be used in any real environment.
+	#
+	secret		= testing123
+
+	#
+	#  Old-style clients do not send a Message-Authenticator
+	#  in an Access-Request.  RFC 5080 suggests that all clients
+	#  SHOULD include it in an Access-Request.  The configuration
+	#  item below allows the server to require it.  If a client
+	#  is required to include a Message-Authenticator and it does
+	#  not, then the packet will be silently discarded.
+	#
+	#  allowed values: yes, no
+	require_message_authenticator = no
+
+	#
+	#  The short name is used as an alias for the fully qualified
+	#  domain name, or the IP address.
+	#
+	#  It is accepted for compatibility with 1.x, but it is no
+	#  longer necessary in 2.0
+	#
+#	shortname	= localhost
+
+	#
+	# the following three fields are optional, but may be used by
+	# checkrad.pl for simultaneous use checks
+	#
+
+	#
+	# The nastype tells 'checkrad.pl' which NAS-specific method to
+	#  use to query the NAS for simultaneous use.
+	#
+	#  Permitted NAS types are:
+	#
+	#	cisco
+	#	computone
+	#	livingston
+	#	juniper
+	#	max40xx
+	#	multitech
+	#	netserver
+	#	pathras
+	#	patton
+	#	portslave
+	#	tc
+	#	usrhiper
+	#	other		# for all other types
+
+	#
+	nas_type     = other	# localhost isn't usually a NAS...
+
+	#
+	#  The following two configurations are for future use.
+	#  The 'naspasswd' file is currently used to store the NAS
+	#  login name and password, which is used by checkrad.pl
+	#  when querying the NAS for simultaneous use.
+	#
+#	login       = !root
+#	password    = someadminpas
+
+	#
+	#  As of 2.0, clients can also be tied to a virtual server.
+	#  This is done by setting the "virtual_server" configuration
+	#  item, as in the example below.
+	#
+#	virtual_server = home1
+
+	#
+	#  A pointer to the "home_server_pool" OR a "home_server"
+	#  section that contains the CoA configuration for this
+	#  client.  For an example of a coa home server or pool,
+	#  see raddb/sites-available/originate-coa
+#	coa_server = coa
+}
 # IPv6 Client
 #client ::1 {
 #	secret		= testing123

--- a/tests/radiusclient-ipv6.conf
+++ b/tests/radiusclient-ipv6.conf
@@ -38,3 +38,6 @@ radius_retries	3
 # local address from which radius packets have to be sent
 bindaddr *
 
+# Transport Protocol Support
+# Use "1" for using UDP and "2" for TCP protocol.
+radius_proto   1

--- a/tests/radiusclient.conf
+++ b/tests/radiusclient.conf
@@ -37,3 +37,6 @@ radius_retries	3
 # local address from which radius packets have to be sent
 bindaddr *
 
+# Transport Protocol Support
+# Use "1" for using UDP and "2" for TCP protocol.
+radius_proto	1

--- a/tests/tcp-tests.sh
+++ b/tests/tcp-tests.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# Copyright (C) 2014 Nikos Mavrogiannopoulos
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "***********************************************"
+echo "This test will use a radius server on localhost"
+echo "and which can be executed with run-server.sh   "
+echo "***********************************************"
+
+TMPFILE=tmp.out
+
+if test -z "$SERVER_IP";then
+	echo "the variable SERVER_IP is not defined"
+	exit 77
+fi
+
+sed 's/localhost/'$SERVER_IP'/g' <$srcdir/radiusclient-tcp.conf >radiusclient-tcp-temp.conf 
+sed 's/localhost/'$SERVER_IP'/g' <$srcdir/servers-tcp >servers-tcp-temp
+
+../src/radiusclient -f radiusclient-tcp-temp.conf  User-Name=test Password=test >$TMPFILE
+if test $? != 0;then
+	echo "Error in PAP auth"
+	exit 1
+fi
+
+grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-Protocol)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Framed-IP-Address                = '192.168.1.190'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-IP-Address)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Framed-Route                     = '192.168.100.5/24'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-Route)"
+	cat $TMPFILE
+	exit 1
+fi
+
+rm -f servers-tcp-temp 
+rm -f $TMPFILE
+rm -f radiusclient-tcp-temp.conf
+
+exit 0

--- a/tests/tcp/radiusclient-tcp.conf
+++ b/tests/tcp/radiusclient-tcp.conf
@@ -1,0 +1,93 @@
+# General settings
+
+# specify which authentication comes first respectively which
+# authentication is used. possible values are: "radius" and "local".
+# if you specify "radius,local" then the RADIUS server is asked
+# first then the local one. if only one keyword is specified only
+# this server is asked.
+auth_order	radius,local
+
+# maximum login tries a user has
+login_tries	4
+
+# timeout for all login tries
+# if this time is exceeded the user is kicked out
+login_timeout	60
+
+# name of the nologin file which when it exists disables logins.
+# it may be extended by the ttyname which will result in
+# a terminal specific lock (e.g. /etc/nologin.ttyS2 will disable
+# logins on /dev/ttyS2)
+nologin /etc/nologin
+
+# name of the issue file. it's only display when no username is passed
+# on the radlogin command line
+issue	/usr/local/etc/radiusclient/issue
+
+# RADIUS settings
+
+# RADIUS server to use for authentication requests. this config
+# item can appear more then one time. if multiple servers are
+# defined they are tried in a round robin fashion if one
+# server is not answering.
+# optionally you can specify a the port number on which is remote
+# RADIUS listens separated by a colon from the hostname. if
+# no port is specified /etc/services is consulted of the radius
+# service. if this fails also a compiled in default is used.
+authserver 	localhost
+
+# RADIUS server to use for accouting requests. All that I
+# said for authserver applies, too. 
+#
+acctserver 	localhost
+
+# file holding shared secrets used for the communication
+# between the RADIUS client and server
+servers		./servers-tcp-temp
+
+# dictionary of allowed attributes and values
+# just like in the normal RADIUS distributions
+dictionary 	../etc/dictionary
+
+# file which specifies mapping between ttyname and NAS-Port attribute
+mapfile		../etc/port-id-map
+
+# default authentication realm to append to all usernames if no
+# realm was explicitly specified by the user
+# the radiusd directly form Livingston doesnt use any realms, so leave
+# it blank then
+default_realm
+
+# time to wait for a reply from the RADIUS server
+radius_timeout	10
+
+# resend request this many times before trying the next server
+radius_retries	3
+
+# The length of time in seconds that we skip a nonresponsive RADIUS
+# server for transaction requests.  Server(s) being in the "dead" state
+# are tried only after all other non-dead servers have been tried and
+# failed or timeouted.  The deadtime interval starts when the server
+# does not respond to an authentication/accounting request transmissions. 
+# When the interval expires, the "dead" server would be re-tried again,
+# and if it's still down then it will be considered "dead" for another
+# such interval and so on. This option is no-op if there is only one
+# server in the list. Set to 0 in order to disable the feature.
+radius_deadtime	0
+
+# local address from which radius packets have to be sent
+bindaddr *
+
+# Transport Protocol Support
+# Use "1" for using UDP and "2" for TCP protocol.
+radius_proto	1
+
+# file which holds sequence number for communication with the
+# RADIUS server
+seqfile		/var/run/radius.seq
+
+# LOCAL settings
+
+# program to execute for local login
+# it must support the -f flag for preauthenticated login
+login_local	/bin/login


### PR DESCRIPTION
By Default, only UDP is used as transport protocol for RADIUS Messages in radcli.

Since FreeRADIUS Server has started supporting TCP in latest releases, added TCP support to radcli to utilize the feature.

Also, the choice of the transport protocol to be used for RADIUS messages is made configurable to user via the configuration file and all the existing interfaces of radcli remain unchanged.
