### PR TITLE
TCP Support

### DIFF
--- a/etc/radiusclient-tls.conf.in
+++ b/etc/radiusclient-tls.conf.in
@@ -50,11 +50,12 @@ bindaddr *
 
 # TLS/DTLS settings
 
-# The type of authentication to use for the radius server.
-# The available options are 'tls' and 'dtls', or should be commented
-# out to use plain UDP. TLS and DTLS authentication can be used
-# with PSK keys or X.509 certificate authentication (see below).
-serv-auth-type	tls
+# Transport Protocol Support
+# Available options - 'tcp', 'udp', 'tls' and 'dtls'. 
+# If commented out, udp will be used
+# TLS and DTLS authentication can be used with PSK keys or X.509 certificate 
+# authentication (see below).
+serv-type   tls
 
 # The CA certificate to be used to verify the server's certificate.
 # Does not need to be set if we are using PSK (pre-shared keys).

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -93,7 +93,8 @@ typedef struct server {
 typedef enum rc_socket_type {
 	RC_SOCKET_UDP = 0,	//!< Plain UDP socket
 	RC_SOCKET_TLS = 1,	//!< TLS socket
-	RC_SOCKET_DTLS = 2	//!< DTLS socket
+	RC_SOCKET_DTLS = 2,	//!< DTLS socket
+	RC_SOCKET_TCP = 3	//!< Plain TCP socket
 } rc_socket_type;
 
 #define AUTH_HDR_LEN			20

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -122,10 +122,30 @@ int rc_aaa_ctx_server(rc_handle * rh, RC_AAA_CTX ** ctx, SERVER * aaaserver,
 	double now = 0;
 	time_t dtime;
 	int servernum;
+	const char *serv_support = NULL;
 
 	data.send_pairs = send;
 	data.receive_pairs = NULL;
 
+	serv_support = rc_conf_str(rh, "serv-type");
+	if (NULL == serv_support){
+        rh->so_type = RC_SOCKET_UDP;
+	}
+	else{
+		if (strcasecmp(serv_support, "dtls") == 0) {
+			rh->so_type = RC_SOCKET_DTLS;
+		} else if (strcasecmp(serv_support, "tls") == 0) {
+			rh->so_type = RC_SOCKET_TLS;
+		} else if (strcasecmp(serv_support, "tcp") == 0) {
+			rh->so_type = RC_SOCKET_TCP;
+		} else if (strcasecmp(serv_support, "udp") == 0) {
+			rh->so_type = RC_SOCKET_UDP;
+		} else {
+			rc_log(LOG_CRIT, "unknown server authentication type: %s", serv_support);
+			return ERROR_RC;
+		}
+	}
+	
 	/*
 	 * if there is more than zero servers, then divide waiting time
 	 * among all the servers.

--- a/lib/config.c
+++ b/lib/config.c
@@ -410,7 +410,7 @@ static int apply_config(rc_handle *rh)
         {
                 const char *txt;
                 int ret;
-                txt = rc_conf_str(rh, "serv-auth-type");
+                txt = rc_conf_str(rh, "serv-type");
                 if (txt != NULL) {
                         if (strcasecmp(txt, "dtls") == 0) {
                                 ret = rc_init_tls(rh, SEC_FLAG_DTLS);

--- a/lib/options.h
+++ b/lib/options.h
@@ -30,7 +30,7 @@ static OPTION config_options_default[] = {
 /* internally used options */
 {"config_file",		OT_STR, ST_UNDEF, NULL},
 /* RADIUS specific options */
-{"serv-auth-type",	OT_STR, ST_UNDEF, NULL},
+{"serv-type",		OT_STR, ST_UNDEF, NULL},
 {"tls-verify-hostname",	OT_STR, ST_UNDEF, NULL},
 {"tls-ca-file",		OT_STR, ST_UNDEF, NULL},
 {"tls-cert-file",	OT_STR, ST_UNDEF, NULL},

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -226,6 +226,17 @@ static ssize_t plain_sendto(void *ptr, int sockfd,
 	return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
 }
 
+static ssize_t plain_tcp_sendto(void *ptr, int sockfd,
+			    const void *buf, size_t len, int flags,
+			    const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+	if((connect(sockfd, dest_addr, addrlen)) != 0){
+		rc_log(LOG_ERR, "%s: Connect Call Failed : %s", __FUNCTION__, strerror(errno));
+		return -1;
+	}
+	return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
 static ssize_t plain_recvfrom(void *ptr, int sockfd,
 			      void *buf, size_t len, int flags,
 			      struct sockaddr *src_addr, socklen_t * addrlen)
@@ -259,10 +270,38 @@ static int plain_get_fd(void *ptr, struct sockaddr *our_sockaddr)
 	return sockfd;
 }
 
+static int plain_tcp_get_fd(void *ptr, struct sockaddr *our_sockaddr)
+{
+	int sockfd;
+
+	sockfd = socket(our_sockaddr->sa_family, SOCK_STREAM, 0);
+	if (sockfd < 0) {
+		return -1;
+	}
+
+	if (our_sockaddr->sa_family == AF_INET)
+		((struct sockaddr_in *)our_sockaddr)->sin_port = 0;
+	else
+		((struct sockaddr_in6 *)our_sockaddr)->sin6_port = 0;
+
+	if (bind(sockfd, SA(our_sockaddr), SA_LEN(our_sockaddr)) < 0) {
+		close(sockfd);
+		return -1;
+	}
+	return sockfd;
+}
+
 const static rc_sockets_override default_socket_funcs = {
 	.get_fd = plain_get_fd,
 	.close_fd = plain_close_fd,
 	.sendto = plain_sendto,
+	.recvfrom = plain_recvfrom
+};
+
+const static rc_sockets_override default_tcp_socket_funcs = {
+	.get_fd = plain_tcp_get_fd,
+	.close_fd = plain_close_fd,
+	.sendto = plain_tcp_sendto,
 	.recvfrom = plain_recvfrom
 };
 
@@ -529,6 +568,8 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 
 	if (rh->so_type == RC_SOCKET_UDP) {
 		sfuncs = &default_socket_funcs;
+	} else if (rh->so_type == RC_SOCKET_TCP) {
+		sfuncs = &default_tcp_socket_funcs;
 	} else {
 		sfuncs = &rh->so;
 

--- a/tests/dtls/radiusclient-tls.conf
+++ b/tests/dtls/radiusclient-tls.conf
@@ -24,7 +24,13 @@ nologin /etc/nologin
 # on the radlogin command line
 issue	/usr/local/etc/freeradius-client/issue
 
-serv-auth-type tls
+# Transport Protocol Support
+# Available options - 'tcp', 'udp', 'tls' and 'dtls'. 
+# If commented out, udp will be used
+# TLS and DTLS authentication can be used with PSK keys or X.509 certificate 
+# authentication (see below).
+serv-type	tls
+
 tls-ca-file dtls/ca.pem
 tls-cert-file dtls/clicert.pem
 tls-key-file dtls/clikey.pem


### PR DESCRIPTION
By Default, only UDP is used as transport protocol for RADIUS Messages in radcli.

Since FreeRADIUS Server has started supporting TCP in latest releases, added TCP support to radcli to utilize the feature.

Also, the choice of the transport protocol to be used for RADIUS messages is made configurable to user via the configuration file and all the existing interfaces of radcli remain unchanged.
