### PR TITLE
doc: Update required dependencies for fedora 23

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,13 @@ Required dependencies (Fedora/RHEL pkg):
 yum install -y autoconf libtool automake gnutls-devel
 ```
 
+
+Required dependencies (Fedora 23+):
+```
+dnf install -y autoconf libtool automake gnutls-devel gettext-devel
+```
+
+
 Required dependencies (Debian pkg):
 ```
 apt-get install -y autoconf libtool automake libgnutls28-dev


### PR DESCRIPTION
Without gettext-devel, running autogen.sh will result in the following error for fedora 23:

configure.ac:104: the top level
configure:14643: error: possibly undefined macro: AC_LIB_PREPARE_PREFIX
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure:14644: error: possibly undefined macro: AC_LIB_PROG_LD
configure:14679: error: possibly undefined macro: AC_LIB_PREPARE_MULTILIB
configure:14694: error: possibly undefined macro: AC_LIB_WITH_FINAL_PREFIX
autoreconf: /usr/bin/autoconf failed with exit status: 1
