### PR TITLE
fix build error for clang

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -67,7 +67,7 @@ double rc_getmtime(void)
     if (clock_gettime(CLOCK_MONOTONIC, &timespec) != 0)
         return -1;
 
-    return timespec.tv_sec + ((double)timespec.tv_nsec) / 1000000000.0d;
+    return timespec.tv_sec + ((double)timespec.tv_nsec) / 1000000000.0;
 #else
     struct timeval timev;
 


### PR DESCRIPTION
error message:
util.c:70:71: error: invalid suffix 'd' on floating constant
    return timespec.tv_sec + ((double)timespec.tv_nsec) / 1000000000.0d;

clang -v
FreeBSD clang version 3.4.1 (tags/RELEASE_34/dot1-final 208032) 20140512
Target: x86_64-unknown-freebsd10.3
Thread model: posix
Selected GCC installation: