### PR TITLE
Fix code that could result in timeout=0

### DIFF
--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -128,19 +128,6 @@ int rc_aaa_ctx_server(rc_handle * rh, RC_AAA_CTX ** ctx, SERVER * aaaserver,
 	data.send_pairs = send;
 	data.receive_pairs = NULL;
 
-	/*
-	 * if there is more than zero servers, then divide waiting time
-	 * among all the servers.
-	 */
-	if (aaaserver->max > 0) {
-		if (timeout > 0) {
-			timeout = (timeout + 1) / aaaserver->max;
-		}
-		if (retries > 0) {
-			retries = (retries + 1) / aaaserver->max;
-		}
-	}
-
 	if (add_nas_port != 0
 	    && rc_avpair_get(data.send_pairs, PW_NAS_PORT, 0) == NULL) {
 		/*


### PR DESCRIPTION
Somebody added code to divide the timeout and retries by the number of servers in an attempt to spread the timeout and retries over the whole group of servers. Unfortunately, this code was not safe and could result in timeout and retries being equal to 0.