### PR TITLE
Copy back AV Pair list to caller on Reject scenarios too

### DIFF
--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -175,7 +175,7 @@ int rc_aaa_ctx_server(rc_handle * rh, RC_AAA_CTX ** ctx, SERVER * aaaserver,
 
 		result = rc_send_server_ctx(rh, ctx, &data, msg, type);
 
-		if ((result == OK_RC) || (result == CHALLENGE_RC)) {
+		if ((result == OK_RC) || (result == CHALLENGE_RC) || (result == REJECT_RC)) {
 			if (request_type != PW_ACCOUNTING_REQUEST) {
 				*received = data.receive_pairs;
 			} else {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,8 +12,8 @@ EXTRA_DIST = radiusclient-ipv6.conf servers-ipv6 \
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/src -I$(top_builddir)
 LDADD = ../lib/libradcli.la
 
-dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh
-TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh
+dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh
+TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh
 check_PROGRAMS =
 
 if ENABLE_GNUTLS

--- a/tests/reject-tests.sh
+++ b/tests/reject-tests.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# Copyright (C) 2017 Aravind Prasad <raja.avi@gmail.com>
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "***********************************************"
+echo "This test will use a radius server on localhost"
+echo "and which can be executed with run-server.sh.  "
+echo "Test passes invalid client credentials and     "
+echo "expects it to be rejected by Server.           "
+echo "***********************************************"
+
+TMPFILE=tmp$$.out
+
+if test -z "$SERVER_IP";then
+	echo "the variable SERVER_IP is not defined"
+	exit 77
+fi
+
+PID=$$
+sed -e 's/localhost/'$SERVER_IP'/g' -e 's/servers-temp/servers-temp'$PID'/g' <$srcdir/radiusclient.conf >radiusclient-temp$PID.conf
+sed 's/localhost/'$SERVER_IP'/g' <$srcdir/servers >servers-temp$PID
+
+echo ../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=admin Password=admin | tee $TMPFILE
+../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=admin Password=admin | tee $TMPFILE
+if test $? = 0;then
+	echo "Authentication passed. Not expected. Error"
+	exit 1
+fi
+
+grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
+if test $? = 0;then
+    echo "Credentials passed here. Credentials should have failed. Error."
+    cat $TMPFILE
+    exit 1
+fi
+
+grep "^Framed-IP-Address                = '192.168.1.190'$" $TMPFILE >/dev/null 2>&1
+if test $? = 0;then
+    echo "Credentials passed here. Credentials should have failed. Error."
+    cat $TMPFILE
+    exit 1
+fi
+
+grep "^Framed-Route                     = '192.168.100.5/24'$" $TMPFILE >/dev/null 2>&1
+if test $? = 0;then
+    echo "Credentials passed here. Credentials should have failed. Error."
+    cat $TMPFILE
+    exit 1
+fi
+
+grep "^Request-Info-Secret = testing123$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+    echo "Info not copied back from Server's Reply. Error"
+    cat $TMPFILE
+    exit 1
+fi
+
+grep "^Request-Info-Vector = " $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+    echo "Info not copied back from Server's Reply. Error"
+    cat $TMPFILE
+    exit 1
+fi
+
+rm -f servers-temp$PID 
+rm -f $TMPFILE
+rm -f radiusclient-temp$PID.conf
+
+exit 0


### PR DESCRIPTION
Copy back the AV-pair list during REJECT scenarios too to the caller. Currently, radcli library copies back the AV-pair list only in case of ACCEPT and CHALLENGE scenarios. But the same should be followed during REJECT scenario too since the decision to process the RADIUS attributes should be with the actual Client(caller) and not with the radcli library.