### PR TITLE
[RDY]  Namespace support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+* Version 1.2.11 (unreleased)
+- Added Namespace support (#30). radcli now supports Namespace on 
+  Linux based systems. 
+
+
+* Version 1.2.10 (unreleased)
+- rc_send_server_ctx: addressed unaligned access issue on certain
+  platforms (#27).
+
+
 * Version 1.2.9 (released 2018-01-20)
 - rc_avpair_gen: addressed issue that caused all attributes to be
   rejected if the last attribute in the message is a VSA with an unknown

--- a/etc/radiusclient-tls.conf.in
+++ b/etc/radiusclient-tls.conf.in
@@ -52,6 +52,11 @@ radius_retries	3
 # local address from which radius packets have to be sent
 bindaddr *
 
+# Namespace in which all sockets of Radcli are to be opened. This is effectively same as the 
+# Radcli existing on that namespace.
+# If commented out, the default existing Namespace will be used.                                    
+#namespace   namespace-name
+
 # TLS/DTLS settings
 
 # Transport Protocol Support

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -57,6 +57,10 @@ bindaddr *
 # If commented out, udp will be used.
 #serv-type   udp
 
+# Namespace in which all sockets of Radcli are to be opened. This is effectively same as the        
+# Radcli existing on that namespace.                                                                 
+# If commented out, the default existing Namespace will be used.                                    
+#namespace   namespace-name                                                                         
 
 # To enable verbose debugging messages in syslog, enable the following
 #clientdebug 1

--- a/lib/options.h
+++ b/lib/options.h
@@ -32,6 +32,7 @@ static OPTION config_options_default[] = {
 /* RADIUS specific options */
 {"serv-type",		OT_STR, ST_UNDEF, NULL},
 {"serv-auth-type",	OT_STR, ST_UNDEF, NULL}, /* alias for serv-type */
+{"namespace",		OT_STR, ST_UNDEF, NULL}, 
 {"tls-verify-hostname",	OT_STR, ST_UNDEF, NULL},
 {"tls-ca-file",		OT_STR, ST_UNDEF, NULL},
 {"tls-cert-file",	OT_STR, ST_UNDEF, NULL},

--- a/lib/tls.c
+++ b/lib/tls.c
@@ -497,13 +497,33 @@ int rc_check_tls(rc_handle * rh)
 void rc_deinit_tls(rc_handle * rh)
 {
 	tls_st *st = rh->so.ptr;
+#ifdef __linux__    
+	char *ns = NULL;
+	int ns_def_hdl = 0;
+#endif    
+
 	if (st) {
+#ifdef __linux__    
+		ns = rc_conf_str(rh, "namespace"); /* Check for namespace config */
+		if (ns != NULL) {
+			if(-1 == rc_set_netns(ns, &ns_def_hdl)) {
+				rc_log(LOG_ERR, "rc_send_server: namespace %s set failed", ns);
+				return;
+			}
+		}
+#endif    
 		if (st->ctx.init != 0)
 			deinit_session(&st->ctx);
 		if (st->x509_cred)
 			gnutls_certificate_free_credentials(st->x509_cred);
 		if (st->psk_cred)
 			gnutls_psk_free_client_credentials(st->psk_cred);
+#ifdef __linux__    
+		if (ns != NULL) {
+			if(-1 == rc_reset_netns(&ns_def_hdl))
+			rc_log(LOG_ERR, "rc_send_server: namespace %s reset failed", ns);
+		}
+#endif    
 	}
 	free(st);
 }
@@ -528,8 +548,22 @@ int rc_init_tls(rc_handle * rh, unsigned flags)
 	SERVER *authservers;
 	char hostname[256];	/* server's hostname */
 	unsigned port;		/* server's port */
+#ifdef __linux__    
+	char *ns = NULL;
+	int ns_def_hdl = 0;
+#endif    
 
 	memset(&rh->so, 0, sizeof(rh->so));
+
+#ifdef __linux__    
+	ns = rc_conf_str(rh, "namespace"); /* Check for namespace config */
+	if (ns != NULL) {
+		if(-1 == rc_set_netns(ns, &ns_def_hdl)) {
+			rc_log(LOG_ERR, "rc_send_server: namespace %s set failed", ns);
+			return -1;
+		}
+	}
+#endif    
 
 	if (flags & SEC_FLAG_DTLS) {
 		rh->so_type = RC_SOCKET_DTLS;
@@ -685,6 +719,14 @@ int rc_init_tls(rc_handle * rh, unsigned flags)
 	rh->so.recvfrom = tls_recvfrom;
 	rh->so.lock = tls_lock;
 	rh->so.unlock = tls_unlock;
+#ifdef __linux__    
+	if (ns != NULL) {
+		if(-1 == rc_reset_netns(&ns_def_hdl)) {
+			rc_log(LOG_ERR, "rc_send_server: namespace %s reset failed", ns);
+			goto cleanup;
+		}
+	}
+#endif    
 	return 0;
  cleanup:
 	if (st) {
@@ -696,6 +738,10 @@ int rc_init_tls(rc_handle * rh, unsigned flags)
 			gnutls_psk_free_client_credentials(st->psk_cred);
 	}
 	free(st);
+	if (ns != NULL) {
+		if(-1 == rc_reset_netns(&ns_def_hdl))
+		rc_log(LOG_ERR, "rc_send_server: namespace %s reset failed", ns);
+	}
 	return ret;
 }
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -48,6 +48,10 @@ struct addrinfo *rc_getaddrinfo (char const *host, unsigned flags);
 void rc_own_bind_addr(rc_handle *rh, struct sockaddr_storage *lia);
 double rc_getmtime(void);
 void rc_str2tm (char const *valstr, struct tm *tm);
+#ifdef __linux__
+int rc_set_netns(const char *net_namespace, int *prev_ns_handle);
+int rc_reset_netns(int *prev_ns_handle);
+#endif
 
 #undef rc_log
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,8 +12,8 @@ EXTRA_DIST = radiusclient-ipv6.conf servers-ipv6 \
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/src -I$(top_builddir)
 LDADD = ../lib/libradcli.la
 
-dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh
-TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh
+dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh
+TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh 
 check_PROGRAMS =
 
 if ENABLE_GNUTLS

--- a/tests/namespace-tests.sh
+++ b/tests/namespace-tests.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+# Copyright (C) 2018 Aravind Prasad S
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "***********************************************"
+echo "This test will use a radius server on localhost"
+echo "and which can be executed with run-server.sh   "
+echo "***********************************************"
+
+TMPFILE=tmp$$.out
+
+if test -z "$SERVER_IP";then
+	echo "the variable SERVER_IP is not defined"
+	exit 77
+fi
+
+PID=$$
+sed -e 's/localhost/'$SERVER_IP'/g' -e 's/servers-temp/servers-temp'$PID'/g' <$srcdir/radiusclient.conf >radiusclient-temp$PID.conf
+sed 's/localhost/'$SERVER_IP'/g' <$srcdir/servers >servers-temp$PID
+NAMESPACE=white
+echo "namespace	$NAMESPACE" >> radiusclient-temp$PID.conf
+
+ip netns | grep $NAMESPACE
+if test $? != 0;then
+	echo "No namespace configured."
+	exit 0
+fi
+
+echo ../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=test Password=test | tee $TMPFILE
+../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=test Password=test | tee $TMPFILE
+if test $? != 0;then
+	echo "Error in PAP auth"
+	exit 1
+fi
+
+grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-Protocol)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Framed-IP-Address                = '192.168.1.190'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-IP-Address)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Framed-Route                     = '192.168.100.5/24'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-Route)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Request-Info-Secret = testing123$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in request info data (secret)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Request-Info-Vector = " $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in request info data (vector)"
+	cat $TMPFILE
+	exit 1
+fi
+
+rm -f servers-temp$PID 
+cat $TMPFILE
+rm -f $TMPFILE
+rm -f radiusclient-temp$PID.conf
+
+exit 0


### PR DESCRIPTION
This pull request adds Namespace support to Radcli. 

Need for Namespace:
------------------------
In actual deployments, Connectivity to RADIUS Server could be configured through different namespace. This is possible in deployments requiring Management-VRF support in Networks Switches/Routers (VRFs could be implemented with Namespaces).

Without it, User will be forced to spawn the Radcli process in different Namespace to transmit/receive messages in that Namespace (Which may not be desired if user expects all processes to be placed in same Namespace).

Few points:
------------
1) Namespace can be configured via the Config file.
2) This functionality is achieved by making Radcli to open all sockets in configured Namespace but the Radcli process continuing to exist in Default Namespace.
3) If no namespace is configured in Config file, no special handling will be done. Things will remain as usual as they exist today. 

Problems in testing this feature in test-suite environment:

Was able to test the changes in my private environment but was unable to do so in the test suite provided in Radcli. 

Tried the following but without success:

1) Was unable to move the Docker interface bridge to any other Namespace. 
2) Changed the Docker file to spawn the Radius server in different Namespace. But no connectivity was possible to Radius Server in the new namespace.

If possible, kindly assist on the same to come up with a test suite to test Namespace changes. 

PS:
Special thanks to Sathishcse57@gmail.com for assisting me in testing various namespace scenarios.