### PR TITLE
Fix for Reject Test failure

### DIFF
--- a/tests/reject-tests.sh
+++ b/tests/reject-tests.sh
@@ -26,10 +26,6 @@ sed 's/localhost/'$SERVER_IP'/g' <$srcdir/servers >servers-temp$PID
 
 echo ../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=admin Password=admin | tee $TMPFILE
 ../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=admin Password=admin | tee $TMPFILE
-if test $? = 0;then
-	echo "Authentication passed. Not expected. Error"
-	exit 1
-fi
 
 grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
 if test $? = 0;then


### PR DESCRIPTION
Issue:
The Reject testcase expects the radiusclient binary call to fail. But it passes and hence, the issue is seen.

Root-cause:
After the commit - https://github.com/radcli/radcli/commit/ce075de8759ac60db4e8eafe05b3d648ec6b5bc8, even incase of Reject scenarios (when REJECT_RC is received), the avpair is copied back to the client and client receives the reply from the RADIUS Server. Hence, radiusclient binary passes. 

Fix:
The check to decide the result of Authentication based on the execution status of radiusclient binary is not correct. The result of authentication should be based on the authentication success parameters returned by RADIUS Server to Client. 

Removed the testcase which was based on the execution status of radiusclient binary. 
