### PR TITLE
Fix compiler warnings[RDY]

### DIFF
--- a/lib/config.c
+++ b/lib/config.c
@@ -1105,11 +1105,10 @@ static int _initialized = 0;
 rc_handle *rc_new(void)
 {
 	rc_handle *rh;
-	int ret;
 
 	if (_initialized == 0) {
-		srandom((unsigned int)(time(NULL)+getpid()));
 #if defined(HAVE_GNUTLS) && GNUTLS_VERSION_NUMBER < 0x030300
+		int ret;
 		ret = gnutls_global_init();
 		if (ret < 0) {
 			rc_log(LOG_ERR,
@@ -1118,6 +1117,7 @@ rc_handle *rc_new(void)
 			return NULL;
 		}
 #endif
+		srandom((unsigned int)(time(NULL)+getpid()));
 	}
 	_initialized++;
 

--- a/tests/tls-restart.c
+++ b/tests/tls-restart.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include <radcli/radcli.h>
 #include <common.h>
@@ -158,7 +159,10 @@ int process(void *rh, VALUE_PAIR * send, int acct, int nas_port)
 
 	fd = rc_tls_fd(rh);
 	if (fd >= 0) {
-		dup(fd);
+		if (dup(fd) == -1) {
+			fprintf(stderr, "tls-restart: dup failed %s", strerror(errno));
+			return 1; 
+		}
 		close(fd);
 	}
 


### PR DESCRIPTION
Fixes the following warning during compilation:
---
1) config.c: In function 'rc_new':
config.c:1108:6: warning: unused variable 'ret' [-Wunused-variable]
  int ret;
      ^
2) common.c:87:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
  (void)write(out, prompt, strlen(prompt));
  ^
3) common.c:111:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
     (void)write(out, &c, 1);
     ^
4) common.c:118:28: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
  if (!do_echo || !is_term) (void)write(out, "\r\n", 2);

5) tls-restart.c: In function ‘process’:
tls-restart.c:161:6: warning: ignoring return value of ‘dup’, declared with attribute warn_unused_result [-Wunused-result]
   dup(fd);
      ^
