### PR TITLE
Use of non-temporary ipv6 address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $SCAN_BUILD ./configure --with-tls
   - $SCAN_BUILD make -j $(nproc)
   - if test $CHECK = 1;then
-      NO_SERVER_TLS=1 NO_SERVER_TCP=1 SERVER_IP=127.0.0.1 SERVER_IP6=127.0.0.1 make check &&
+      sudo NO_SERVER_TLS=1 NO_SERVER_TCP=1 SERVER_IP=127.0.0.1 SERVER_IP6=127.0.0.1 make check &&
       touch doc/stamp_mans &&
       make ABI_SKIP=1 dist;
     fi

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@
 - rc_read_dictionary_from_buffer: introduced new function; this
   is required to load dictionary attributes from string buffer
   (#24)
+- Added non-temporary IPv6 address support (#23). This enables
+  radcli to use Global IPv6 address instead of temporary IPv6
+  address as source address for packets sent out when IPv6 
+  Privacy Extensions are enabled in system.
 
 * Version 1.2.10 (released 2018-05-08)
 - rc_send_server_ctx: addressed unaligned access issue on certain

--- a/etc/radiusclient-tls.conf.in
+++ b/etc/radiusclient-tls.conf.in
@@ -57,6 +57,14 @@ bindaddr	*
 # If commented out, the default existing Namespace will be used.                                    
 #namespace   namespace-name
 
+# Support for IPv6 non-temporary address support. This is an IPv6-only option
+# and is valid only when IPv6 Privacy Extensions are enabled in system.
+# If this option is set to "true", the radius packets will be sent with the
+# IPv6 Global address and will not use the temporary adresses. If commented
+# out, temporary IPv6 addresses will be used as source address for the packets
+# sent.
+#use-public-addr	true
+
 # TLS/DTLS settings
 
 # Transport Protocol Support

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -62,5 +62,13 @@ bindaddr	*
 # If commented out, the default existing Namespace will be used.                                    
 #namespace   namespace-name                                                                         
 
+# Support for IPv6 non-temporary address support. This is an IPv6-only option
+# and is valid only when IPv6 Privacy Extensions are enabled in system.
+# If this option is set to "true", the radius packets will be sent with the
+# IPv6 Global address and will not use the temporary adresses. If commented
+# out, temporary IPv6 addresses will be used as source address for the packets
+# sent.
+#use-public-addr	true
+
 # To enable verbose debugging messages in syslog, enable the following
 #clientdebug 1

--- a/lib/options.h
+++ b/lib/options.h
@@ -33,6 +33,7 @@ static OPTION config_options_default[] = {
 {"serv-type",		OT_STR, ST_UNDEF, NULL},
 {"serv-auth-type",	OT_STR, ST_UNDEF, NULL}, /* alias for serv-type */
 {"namespace",		OT_STR, ST_UNDEF, NULL}, 
+{"use-public-addr",	OT_STR, ST_UNDEF, NULL},
 {"tls-verify-hostname",	OT_STR, ST_UNDEF, NULL},
 {"tls-ca-file",		OT_STR, ST_UNDEF, NULL},
 {"tls-cert-file",	OT_STR, ST_UNDEF, NULL},

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,8 +12,8 @@ EXTRA_DIST = radiusclient-ipv6.conf servers-ipv6 \
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/src -I$(top_builddir)
 LDADD = ../lib/libradcli.la
 
-dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh
-TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh 
+dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh
+TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh
 check_PROGRAMS =
 
 if ENABLE_GNUTLS

--- a/tests/ipv6-non-temp-addr-tests.sh
+++ b/tests/ipv6-non-temp-addr-tests.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+# Copyright (C) 2018 Aravind Prasad S
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "***********************************************"
+echo "This test will use a radius server on localhost"
+echo "and which can be executed with run-server.sh   "
+echo "***********************************************"
+
+TMPFILE=tmp$$.out
+
+if test "$(id -u)" != "0";then
+	echo "This test must be run as root"
+	exit 77
+fi
+
+#Identify the platform
+OS="`uname`"
+case $OS in
+  'Linux')
+    OS='Linux'
+    ;;
+  'FreeBSD')
+    OS='FreeBSD'
+    ;;
+  'Darwin') 
+    OS='Mac'
+    ;;
+  *) 
+    OS='None'
+    ;;
+esac
+
+#Check if the platform is supported
+if test $OS = "None"; then
+	echo "Platform not supported. Tests cannot be done"
+	exit 77
+fi
+
+if test -z "$SERVER_IP6"; then
+	echo "the variable SERVER_IP6 is not defined"
+	exit 77
+fi
+
+PID=$$
+sed -e 's/::1/'$SERVER_IP6'/g' -e 's/servers-ipv6-temp/servers-ipv6-temp'$PID'/g' <$srcdir/radiusclient-ipv6.conf >radiusclient-temp$PID.conf
+sed 's/::1/'$SERVER_IP6'/g' <$srcdir/servers-ipv6 >servers-ipv6-temp$PID                            
+echo "use-public-addr	true" >> radiusclient-temp$PID.conf
+
+#enable ipv6 privay settings
+sysctl -w net.ipv6.conf.all.use_tempaddr=2
+#set interval=1 for generation of new temporary ipv6 addresses
+sysctl -w net.ipv6.conf.all.temp_prefered_lft=1
+#restart interfaces in Debian based system 
+systemctl restart networking
+if test $? != 0; then
+	#restart interfaces in Fedora based system 
+	systemctl restart network
+fi    
+
+#wait for 2 seconds for generation of new temporary ipv6 address
+sleep 2
+
+#radius-client is expected to use the global ipv6 address and not temporary address now
+echo ../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=test Password=test6 | tee $TMPFILE
+../src/radiusclient -D -i -f radiusclient-temp$PID.conf  User-Name=test6 Password=test | tee $TMPFILE
+if test $? != 0;then
+	echo "Error in PAP auth"
+	sysctl -w net.ipv6.conf.all.use_tempaddr=0
+	sysctl -w net.ipv6.conf.all.temp_prefered_lft=86400
+	exit 1
+fi
+
+grep "^Framed-IPv6-Prefix               = '2000:0:0:106::/64'$" $TMPFILE >/dev/null 2>&1            
+if test $? != 0;then                                                                                
+	echo "Error in data received by server (Framed-IPv6-Prefix)"                                    
+	cat $TMPFILE                                                                                    
+	sysctl -w net.ipv6.conf.all.use_tempaddr=0
+	sysctl -w net.ipv6.conf.all.temp_prefered_lft=86400
+	exit 1                                                                                          
+fi                                                                                                  
+
+rm -f servers-temp$PID 
+cat $TMPFILE
+rm -f $TMPFILE
+rm -f radiusclient-temp$PID.conf
+sysctl -w net.ipv6.conf.all.use_tempaddr=0
+sysctl -w net.ipv6.conf.all.temp_prefered_lft=86400
+
+exit 0


### PR DESCRIPTION
Fix for https://github.com/radcli/radcli/issues/23 

Issue Description:
In Linux,/BSD/Apple-OS, it is possible to enable temporary IPv6 addresses in system by default (when IPv6 Privacy Extensions are enabled in system). In this scenario, with default settings (if bindaddr option is set
to "*" in config file), the radius client will use the temporary ipv6 address as source address for the packets sent out. This is usually not desired since the RADIUS Server identifies the RADIUS Client usually by a unique address and continuously changing IPV6 addresses requires changes in RADIUS Server config too which is not preferable.

Fix:
In these cases, it is preferable to make Radius Client to use Global IPv6 address as source address for packets sent out.

Changes made:
Introduced a config file option to specify support of IPV6 non-temporary address support. If this option is set to "true" in config file, Radius Client will use Global IPv6 address as source address for packets sent out.