### PR TITLE
Fix Docker build issue [RDY]

### DIFF
--- a/tests/docker/Dockerfile-radius
+++ b/tests/docker/Dockerfile-radius
@@ -1,5 +1,6 @@
 FROM fedora:21
 
+RUN yum install -y yum-plugin-ovl
 RUN yum install -y openssh-server
 RUN yum install -y freeradius
 RUN sed 's/PermitRootLogin without-password/PermitRootLogin yes/g' -i /etc/ssh/sshd_config

--- a/tests/run-server.sh
+++ b/tests/run-server.sh
@@ -100,6 +100,11 @@ if test -z "$IP";then
 	echo "Detected IP is null!"
 	stop
 fi
-echo "$IP"
+
+serv_ip=$( echo $IP | cut -d' ' -f1 )
+
+echo ""
+echo "Server IP = $serv_ip"
+echo "Command to run the tests => \"SERVER_IP=$serv_ip SERVER_IP6=$serv_ip make check\""
 
 exit 0


### PR DESCRIPTION
1) Fix for issue - https://github.com/radcli/radcli/issues/46 
 
Description:
"yum install -y yum-plugin-ovl" was needed in Docker file for the build to pass.

from MAN page:
Opening a file on OverlayFS in read-only mode causes the file from
       lower layer to be opened, then later on, if the same file is opened
       in write mode, a copy-up into the upper    layer    takes    place,
       resulting into a new file being opened.
       Since yum(8) needs to open the RPMdb first read-only, and then
       also with write access, we need to copy-up the files beforehand to
       make sure that the access is consistent.

2) Cleanup of run-server.sh file to display the Server IP and command to run the tests