### PR TITLE
Add support for connect() errno=ENETUNREACH

### DIFF
--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -451,6 +451,7 @@ typedef struct dict_vendor
 /** \enum rc_send_status Return codes for rc_send_server()
  */
 typedef enum rc_send_status {
+	NETUNREACH_RC=-4,
 	BADRESPID_RC=-3,
 	BADRESP_RC=-2,
 	ERROR_RC=-1,

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -190,11 +190,10 @@ int rc_aaa_ctx_server(rc_handle * rh, RC_AAA_CTX ** ctx, SERVER * aaaserver,
 		rc_avpair_free(data.receive_pairs);
 		data.receive_pairs = NULL;
 
-		if (radcli_debug) {
-			rc_log(LOG_INFO, "rc_send_server_ctx returned error (%d) for server %u: (remaining: %d)", result, servernum, aaaserver->max-servernum);
-		}
+		DEBUG(LOG_INFO, "rc_send_server_ctx returned error (%d) for server %u: (remaining: %d)",
+              result, servernum, aaaserver->max-servernum);
 		servernum++;
-	} while (servernum < aaaserver->max && result == TIMEOUT_RC);
+	} while (servernum < aaaserver->max && ((result == TIMEOUT_RC) || (result == NETUNREACH_RC)));
 
 	return result;
 }

--- a/lib/ip_util.c
+++ b/lib/ip_util.c
@@ -131,9 +131,11 @@ int rc_get_srcaddr(struct sockaddr *lia, const struct sockaddr *ria)
 	}
 
 	if (connect(temp_sock, ria, SA_LEN(ria)) != 0) {
+		int e = errno; // Preserve connect's errno
 		rc_log(LOG_ERR, "rc_get_srcaddr: connect: %s",
 		    strerror(errno));
 		close(temp_sock);
+		errno = e;     // Make connect's errno available to caller
 		return -1;
 	}
 

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -542,10 +542,10 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 	if (discover_local_ip) {
 		result = rc_get_srcaddr(SA(&our_sockaddr), auth_addr->ai_addr);
 		if (result != 0) {
+			result = errno == ENETUNREACH ? NETUNREACH_RC : ERROR_RC;
 			memset(secret, '\0', sizeof(secret));
 			rc_log(LOG_ERR,
 			       "rc_send_server: cannot figure our own address");
-			result = ERROR_RC;
 			goto cleanup;
 		}
 	}
@@ -703,9 +703,9 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 					   auth_addr->ai_addrlen);
 		} while (result == -1 && errno == EINTR);
 		if (result == -1) {
+			result = errno == ENETUNREACH ? NETUNREACH_RC : ERROR_RC;
 			rc_log(LOG_ERR, "%s: socket: %s", __FUNCTION__,
 			       strerror(errno));
-			result = ERROR_RC;
 			goto cleanup;
 		}
 

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -541,8 +541,7 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 	      server_name);
 	if (discover_local_ip) {
 		result = rc_get_srcaddr(SA(&our_sockaddr), auth_addr->ai_addr);
-		if (result != 0) {
-			result = errno == ENETUNREACH ? NETUNREACH_RC : ERROR_RC;
+		if (result != OK_RC) {
 			memset(secret, '\0', sizeof(secret));
 			rc_log(LOG_ERR,
 			       "rc_send_server: cannot figure our own address");


### PR DESCRIPTION
radcli will now continue with the next RADIUS server configured (if any) when [connect()](http://man7.org/linux/man-pages/man2/connect.2.html) fails with `errno=ENETUNREACH` (Network Unreachable). This may happen, for example, when a route cannot be found for the configured RADIUS servers.

This condition is hard to reproduce. In order for `connect()` to return `errno=ENETUNREACH` you basically need to have no routes to the specified IP address. Most of the times a "default route" exists and you would not normally see this condition happen. On the systems I work on we often remove the default route and only use specific routes (for security reasons). For example, we may define only one route as follows:
```
$ ip route
10.0.0.0/8 dev eth0 proto kernel scope link src 10.11.86.129
```
@nmav, I cannot provide a unit test script for this as the script would need to change the routing tables of the computer running the test (which I'm pretty sure nobody wants) in order to cause `connect()` to return `errno=ENETUNREACH`. Please let me know if you think of a way to cause the error to happen that doesn't involve modifying the network configuration of the computer running the test.