### PR TITLE
Fix build on platforms that do not have LOG_PERROR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,12 @@ AC_CHECK_HEADERS(signal.h sys/signal.h sys/stat.h)
 AC_CHECK_HEADERS(fcntl.h sys/fcntl.h)
 AC_CHECK_HEADERS(sys/utsname.h getopt.h unistd.h)
 AC_CHECK_HEADERS(sys/file.h termios.h sys/ioctl.h)
-AC_CHECK_HEADERS(netdb.h syslog.h pwd.h)
+AC_CHECK_HEADERS(netdb.h pwd.h)
+AC_CHECK_HEADERS([syslog.h])
+if test "x$ac_cv_header_syslog_h" = "xyes"
+then
+	AC_CHECK_DECLS([LOG_PERROR], [], [], [[#include <syslog.h>]])
+fi
 AC_CHECK_HEADERS(sys/socket.h netinet/in.h arpa/inet.h)
 if test "$shadow_passwords" = "yes"
 then

--- a/src/radiusclient.c
+++ b/src/radiusclient.c
@@ -125,7 +125,11 @@ main(int argc, char **argv)
 
     if(debug) {
       rc_setdebug(1);
+#if HAVE_DECL_LOG_PERROR
       openlog("radiusclient", LOG_PERROR|LOG_NDELAY, LOG_LOCAL7);
+#else
+      openlog("radiusclient", LOG_NDELAY, LOG_LOCAL7);
+#endif
     } else {
       openlog("radiusclient", LOG_NDELAY, LOG_AUTH);
     }


### PR DESCRIPTION
Some platforms such as Solaris do no have LOG_PERROR.  This change uses autoconf to detect that and #ifdef accordingly.

Closes #55