### PR TITLE
radcli.pc.in: Fix typo

### DIFF
--- a/lib/radcli.pc.in
+++ b/lib/radcli.pc.in
@@ -7,7 +7,7 @@ includedir=@includedir@
 
 Name: radcli
 Description: A small radius client library
-URL: http://radcli.github.io/libradcli/
+URL: http://radcli.github.io/radcli/
 Version: @VERSION@
 Libs: -L${libdir} -lradcli
 @REQUIRES_PRIVATE@


### PR DESCRIPTION
This was copy-and-paste mistake in commit 665c4ae.