### PR TITLE
Fix typos found by codespell

### DIFF
--- a/doc/man/radcli.h.3
+++ b/doc/man/radcli.h.3
@@ -89,7 +89,7 @@ int            rc_tls_fd(rc_handle *);
 struct send_data {
   uint8_t      \fIcode\fP;          // RADIUS packet code. 
   uint8_t      \fIseq_nbr\fP;       // Packet sequence number. 
-  char        *\fIserver\fP;        // Name/addrress of RADIUS server. 
+  char        *\fIserver\fP;        // Name/address of RADIUS server. 
   int          \fIsvc_port\fP;      // RADIUS protocol destination port. 
   char        *\fIsecret\fP;        // Shared secret of RADIUS server. 
   int          \fItimeout\fP;       // Session timeout in seconds. 

--- a/doc/man/rc_buildreq.3
+++ b/doc/man/rc_buildreq.3
@@ -65,7 +65,7 @@ the number of retries.
 struct send_data {
   uint8_t      \fIcode\fP;          // RADIUS packet code. 
   uint8_t      \fIseq_nbr\fP;       // Packet sequence number. 
-  char        *\fIserver\fP;        // Name/addrress of RADIUS server. 
+  char        *\fIserver\fP;        // Name/address of RADIUS server. 
   int          \fIsvc_port\fP;      // RADIUS protocol destination port. 
   char        *\fIsecret\fP;        // Shared secret of RADIUS server. 
   int          \fItimeout\fP;       // Session timeout in seconds. 

--- a/doc/man/rc_send_server.3
+++ b/doc/man/rc_send_server.3
@@ -45,7 +45,7 @@ must be AUTH or ACCT
 struct send_data {
   uint8_t      \fIcode\fP;          // RADIUS packet code. 
   uint8_t      \fIseq_nbr\fP;       // Packet sequence number. 
-  char        *\fIserver\fP;        // Name/addrress of RADIUS server. 
+  char        *\fIserver\fP;        // Name/address of RADIUS server. 
   int          \fIsvc_port\fP;      // RADIUS protocol destination port. 
   char        *\fIsecret\fP;        // Shared secret of RADIUS server. 
   int          \fItimeout\fP;       // Session timeout in seconds. 
@@ -58,7 +58,7 @@ struct send_data {
 .RE
 .SH RETURN VALUE
 .PP
-OK_RC (0) on success, TIMEOUT_RC on timeout REJECT_RC on acess reject, or negative on failure as return value. 
+OK_RC (0) on success, TIMEOUT_RC on timeout REJECT_RC on access reject, or negative on failure as return value. 
 .SH SEE ALSO
 .PP
 .nh

--- a/etc/radiusclient-tls.conf.in
+++ b/etc/radiusclient-tls.conf.in
@@ -39,7 +39,7 @@ dictionary	@pkgsysconfdir@/dictionary
 
 # default authentication realm to append to all usernames if no
 # realm was explicitly specified by the user
-# the radiusd directly form Livingston doesnt use any realms, so leave
+# the radiusd directly form Livingston doesn't use any realms, so leave
 # it blank then
 default_realm
 
@@ -60,7 +60,7 @@ bindaddr	*
 # Support for IPv6 non-temporary address support. This is an IPv6-only option
 # and is valid only when IPv6 Privacy Extensions are enabled in system.
 # If this option is set to "true", the radius packets will be sent with the
-# IPv6 Global address and will not use the temporary adresses. If commented
+# IPv6 Global address and will not use the temporary addresses. If commented
 # out, temporary IPv6 addresses will be used as source address for the packets
 # sent.
 #use-public-addr	true

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -22,7 +22,7 @@
 authserver 	localhost
 #authserver 	127.1.1.1:9999,172.17.0.1
 
-# RADIUS server to use for accouting requests. All that is
+# RADIUS server to use for accounting requests. All that is
 # written for authserver applies, in acctserver as well. 
 #
 acctserver 	localhost
@@ -39,7 +39,7 @@ dictionary 	@pkgsysconfdir@/dictionary
 
 # default authentication realm to append to all usernames if no
 # realm was explicitly specified by the user
-# the radiusd directly form Livingston doesnt use any realms, so leave
+# the radiusd directly form Livingston doesn't use any realms, so leave
 # it blank then
 default_realm
 
@@ -65,7 +65,7 @@ bindaddr	*
 # Support for IPv6 non-temporary address support. This is an IPv6-only option
 # and is valid only when IPv6 Privacy Extensions are enabled in system.
 # If this option is set to "true", the radius packets will be sent with the
-# IPv6 Global address and will not use the temporary adresses. If commented
+# IPv6 Global address and will not use the temporary addresses. If commented
 # out, temporary IPv6 addresses will be used as source address for the packets
 # sent.
 #use-public-addr	true

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -487,7 +487,7 @@ typedef struct send_data /* Used to pass information to sendserver() function */
 {
 	uint8_t        code;		//!< RADIUS packet code.
 	uint8_t        seq_nbr;		//!< Packet sequence number.
-	char           *server;		//!< Name/addrress of RADIUS server.
+	char           *server;		//!< Name/address of RADIUS server.
 	int            svc_port;	//!< RADIUS protocol destination port.
 	char           *secret;		//!< Shared secret of RADIUS server.
 	int            timeout;		//!< Session timeout in seconds.

--- a/lib/config.c
+++ b/lib/config.c
@@ -714,7 +714,7 @@ char *rc_conf_str(rc_handle const *rh, char const *optname)
 	if (option != NULL) {
 		return (char *)option->val;
 	} else {
-		rc_log(LOG_CRIT, "rc_conf_str: unkown config option requested: %s", optname);
+		rc_log(LOG_CRIT, "rc_conf_str: unknown config option requested: %s", optname);
 		return NULL;
 	}
 }
@@ -739,7 +739,7 @@ static int rc_conf_int_2(rc_handle const *rh, char const *optname, int complain)
 		}
                 return 0;
 	} else {
-		rc_log(LOG_CRIT, "rc_conf_int: unkown config option requested: %s", optname);
+		rc_log(LOG_CRIT, "rc_conf_int: unknown config option requested: %s", optname);
 		return 0;
 	}
 }
@@ -764,7 +764,7 @@ SERVER *rc_conf_srv(rc_handle const *rh, char const *optname)
 	if (option != NULL) {
 		return (SERVER *)option->val;
 	} else {
-		rc_log(LOG_CRIT, "rc_conf_srv: unkown config option requested: %s", optname);
+		rc_log(LOG_CRIT, "rc_conf_srv: unknown config option requested: %s", optname);
 		return NULL;
 	}
 }

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -109,7 +109,7 @@ static int rc_pack_list(VALUE_PAIR * vp, char *secret, AUTH_HDR * auth)
 				rc_md5_calc(buf, md5buf,
 					    secretlen + AUTH_VECTOR_LEN);
 
-				/* Remeber the start of the digest */
+				/* Remember the start of the digest */
 				vector = buf;
 
 				/* Xor the password into the MD5 digest */
@@ -226,7 +226,7 @@ static int populate_ctx(RC_AAA_CTX ** ctx, char secret[MAX_SECRET_LENGTH + 1],
  * @param msg must be an array of %PW_MAX_MSG_SIZE or NULL; will contain the concatenation of
  *	any %PW_REPLY_MESSAGE received.
  * @param type must be %AUTH or %ACCT
- * @return OK_RC (0) on success, TIMEOUT_RC on timeout REJECT_RC on acess reject, or negative
+ * @return OK_RC (0) on success, TIMEOUT_RC on timeout REJECT_RC on access reject, or negative
  *	on failure as return value.
  */
 int rc_send_server(rc_handle * rh, SEND_DATA * data, char *msg, rc_type type)
@@ -421,7 +421,7 @@ static int add_msg_auth_attr(rc_handle * rh, char * secret,
 	total_length += 18;
 	auth->length = htons((unsigned short)total_length);
 
-	/* Calulate HMAC-MD5 [RFC2104] hash */
+	/* Calculate HMAC-MD5 [RFC2104] hash */
 	uint8_t digest[MD5_DIGEST_SIZE];
 	rc_hmac_md5((uint8_t *)auth, (size_t)total_length, (uint8_t *)secret, secretlen, digest);
 	memcpy(&msg_auth[2], digest, MD5_DIGEST_SIZE);

--- a/src/common.c
+++ b/src/common.c
@@ -22,7 +22,7 @@
 
 #define	RC_BUFSIZ	1024
 
-/** Reads in a string from the user (with or witout echo)
+/** Reads in a string from the user (with or without echo)
  *
  * @param rh a handle to parsed configuration.
  * @param prompt the prompt to print.

--- a/src/radembedded.c
+++ b/src/radembedded.c
@@ -59,7 +59,7 @@ main (int argc, char **argv)
 	rh = rc_config_init(rh);
 	if (rh == NULL)
 	{
-		printf("ERROR: Failed to initialze configuration\n");
+		printf("ERROR: Failed to initialize configuration\n");
 		exit(1);
 	}
 

--- a/src/radembedded_dict.c
+++ b/src/radembedded_dict.c
@@ -154,7 +154,7 @@ main (int argc, char **argv)
 	rh = rc_config_init(rh);
 	if (rh == NULL)
 	{
-	    printf("ERROR: Failed to initialze configuration\n");
+	    printf("ERROR: Failed to initialize configuration\n");
 	    exit(1);
 	}
 

--- a/src/radius.c
+++ b/src/radius.c
@@ -73,7 +73,7 @@ LFUNC auth_radius(rc_handle *rh, uint32_t client_port, char const *username, cha
 	if (rc_avpair_add(rh, &send, PW_SERVICE_TYPE, &service, -1, 0) == NULL)
 		return NULL;
 
-	/* Fill in Framed-Protocol, if neccessary */
+	/* Fill in Framed-Protocol, if necessary */
 
 	if (ftype != 0)
 	{
@@ -81,7 +81,7 @@ LFUNC auth_radius(rc_handle *rh, uint32_t client_port, char const *username, cha
 			return NULL;
 	}
 
-	/* Fill in Framed-Compression, if neccessary */
+	/* Fill in Framed-Compression, if necessary */
 
 	if (ctype != 0)
 	{

--- a/tests/dict-add.c
+++ b/tests/dict-add.c
@@ -67,7 +67,7 @@ main (int argc, char **argv)
     rh = rc_config_init(rh);
     if (rh == NULL)
     {
-        printf("ERROR: Failed to initialze configuration\n");
+        printf("ERROR: Failed to initialize configuration\n");
         exit(1);
     }
 

--- a/tests/dict.c
+++ b/tests/dict.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
 
 	rh = rc_config_init(rh);
 	if (rh == NULL) {
-		printf("ERROR: Failed to initialze configuration\n");
+		printf("ERROR: Failed to initialize configuration\n");
 		exit(1);
 	}
 

--- a/tests/dtls/radiusclient-tls.conf
+++ b/tests/dtls/radiusclient-tls.conf
@@ -42,13 +42,13 @@ tls-verify-hostname false
 # item can appear more than one time. If multiple servers are
 # defined they are tried in a round robin fashion if one server
 # is not answering.
-# Optionally, you can specify the port number on which thes remote
+# Optionally, you can specify the port number on which the remote
 # RADIUS server listens separated by a colon from the hostname.
 # If no port is specified, /etc/services is consulted for the radius
 # service. If this fails also a compiled in default is used.
 authserver localhost:2083
 
-# RADIUS server to use for accouting requests.
+# RADIUS server to use for accounting requests.
 # All settings for authserver apply, too.
 #
 acctserver localhost:2083

--- a/tests/raddb-tcp/clients.conf
+++ b/tests/raddb-tcp/clients.conf
@@ -499,7 +499,7 @@ client localhost-tcp {
 #  the same as above, but they are nested inside of a section.
 #
 #  You can have as many per-socket client lists as you have "listen"
-#  sections, or you can re-use a list among multiple "listen" sections.
+#  sections, or you can reuse a list among multiple "listen" sections.
 #
 #  Un-comment this section, and edit a "listen" section to add:
 #  "clients = per_socket_clients".  That IP address/port combination

--- a/tests/raddb/clients.conf
+++ b/tests/raddb/clients.conf
@@ -360,7 +360,7 @@ client localhost2 {
 #  the same as above, but they are nested inside of a section.
 #
 #  You can have as many per-socket client lists as you have "listen"
-#  sections, or you can re-use a list among multiple "listen" sections.
+#  sections, or you can reuse a list among multiple "listen" sections.
 #
 #  Un-comment this section, and edit a "listen" section to add:
 #  "clients = per_socket_clients".  That IP address/port combination

--- a/tests/radiusclient-ipv6.conf
+++ b/tests/radiusclient-ipv6.conf
@@ -7,7 +7,7 @@
 # service. In case this fails also a compiled in default is used.
 authserver	[::1]
 
-# RADIUS server to use for accouting requests.
+# RADIUS server to use for accounting requests.
 # All settings for authserver apply, too.
 #
 acctserver	[::1]

--- a/tests/radiusclient.conf
+++ b/tests/radiusclient.conf
@@ -9,7 +9,7 @@ nas-identifier my-nas-id
 # service. In case this fails a compiled in default is used.
 authserver	localhost
 
-# RADIUS server to use for accouting requests.
+# RADIUS server to use for accounting requests.
 # All settings for authserver apply, too.
 #
 acctserver	localhost


### PR DESCRIPTION
I have tried to leaved out files imported from different software such as [FreeRADIUS](https://github.com/FreeRADIUS/freeradius-server):
```
tests/raddb-tcp/radiusd.conf
tests/raddb/radiusd.conf
```