### PR TITLE
Bump the shared secret maximum length to 256

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,8 @@
 * Version 1.3.2 (unreleased)
+- Bump the maximal length of the password to 128, as required by
+  RFC 2865.
+- Bump the maximal length of the shared secret to 256. It should match
+  or exceed the maximal length supported by most RADIUS servers.
 - New helper macros to set vendor and attribute
    - RADCLI_VENDOR_ATTR_SET
    - RADCLI_VENDOR_MASK

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_SUBST(NUMBER_VERSION, `printf "0x%02x%02x%02x" $MAJOR_VERSION $MINOR_VERSION 
 # Interfaces changed/added/removed:   CURRENT++       REVISION=0
 # Interfaces added:                             AGE++
 # Interfaces removed:                           AGE=0
-V_CURRENT=8
+V_CURRENT=9
 V_REVISION=0
 V_AGE=3
 LIBVERSION="$V_CURRENT:$V_REVISION:$V_AGE"

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -46,14 +46,14 @@ extern "C" {
  * @{
  */
 
-#define AUTH_PASS_LEN		(7 * 16) /* multiple of 16 */
+#define AUTH_PASS_LEN		(8 * 16) /* multiple of 16 */
 #define AUTH_ID_LEN		64
 
 #define RC_BUFFER_LEN		8192
 
 #define RC_NAME_LENGTH		32
 
-#define MAX_SECRET_LENGTH	(6 * 16) /* MUST be multiple of 16 */
+#define MAX_SECRET_LENGTH	(16 * 16) /* MUST be multiple of 16 */
 
 #define RADCLI_VENDOR_MASK 0xffffffff
 #define VENDOR_BIT_SIZE		32


### PR DESCRIPTION
* The FreeRADIUS library bumped it from `6 * 16` to `16 * 16` as well:
  https://github.com/FreeRADIUS/freeradius-client/issues/112
  https://github.com/FreeRADIUS/freeradius-client/commit/6ec5f43
* A value of 256 covers most commercial RADIUS servers, except the AWS Directory Service with an upper limit of 512 characters.
* In practice, I doubt anyone uses shared secrets larger than 256 out there.

Fixes #103.