### PR TITLE
The RADIUS Accounting service name is `radius-acct`

### DIFF
--- a/lib/ip_util.c
+++ b/lib/ip_util.c
@@ -39,7 +39,7 @@ struct addrinfo *rc_getaddrinfo (char const *host, unsigned flags)
 	if (flags & PW_AI_AUTH)
 		service = "radius";
 	else if (flags & PW_AI_ACCT)
-		service = "radacct";
+		service = "radius-acct";
  
 	err = getaddrinfo(host, service, &hints, &res);
 	if (err != 0) {


### PR DESCRIPTION
Verified in the `/etc/services` file of ArchLinux and Ubuntu 20.04 and 24.04.

Besides, that's what the FreeRADIUS client uses.

Fixes #109.