### PR TITLE
Add Message-Authenticator attribute to all requests

### DIFF
--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -670,11 +670,9 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 		total_length =
 		    rc_pack_list(data->send_pairs, secret, auth) + AUTH_HDR_LEN;
 
-		auth->length = htons((unsigned short)total_length);
+		total_length = add_msg_auth_attr(rh, secret, auth, total_length);
 
-		/* If EAP message we MUST add a Message-Authenticator attribute */
-		if (rc_avpair_get(data->send_pairs, PW_EAP_MESSAGE, 0) != NULL)
-		    total_length = add_msg_auth_attr(rh, secret, auth, total_length);
+		auth->length = htons((unsigned short)total_length);
 	}
 
 	if (radcli_debug) {

--- a/tests/basic-tests.sh
+++ b/tests/basic-tests.sh
@@ -34,6 +34,13 @@ if test $? != 0;then
 	exit 1
 fi
 
+grep "^Message-Authenticator            = " $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in request info data (Message-Authenticator)"
+	cat $TMPFILE
+	exit 1
+fi
+
 grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
 if test $? != 0;then
 	echo "Error in data received by server (Framed-Protocol)"


### PR DESCRIPTION
This closes issue #107. The Message-Authenticator attribute is optional for non-EAP requests, but some providers (such as Okta) may require this attibute for all requests.

The basic test has been updated to check for this attribute.