### PR TITLE
Validate Message-Authenticator attribute

### DIFF
--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -442,23 +442,17 @@ static int validate_message_authenticator(VALUE_PAIR *vp, const uint8_t *recv_bu
 	uint8_t *idx = verify_buffer + AUTH_HDR_LEN;
 	const char *received_message_authenticator = NULL;
 
-	/* Reconstruct the original packet, but fill the Message-Authenticator value with zeroes instead */
-	memset(verify_buffer, 0, sizeof(verify_buffer));
-	memcpy(verify_buffer, recv_buffer, AUTH_HDR_LEN);
+	/* Copy the original packet, and clear the Message-Authenticator value */
+	memcpy(verify_buffer, recv_buffer, AUTH_HDR_LEN + length);
 	for (; vp != NULL; vp = vp->next) {
-		*idx++ = vp->attribute;
+		idx += 2;
 		if (!rc_avpair_get_uint32(vp, NULL)) {
-			*idx++ = 6;
-			const uint32_t value = ntohl(vp->lvalue);
-			memcpy(idx, &value, 4);
 			idx += 4;
 		} else if (vp->attribute == PW_MESSAGE_AUTHENTICATOR) {
-			*idx++ = vp->lvalue + 2;
-			idx += vp->lvalue;
+			memset(idx, '\0', vp->lvalue);
 			received_message_authenticator = vp->strvalue;
+			break;
 		} else {
-			*idx++ = vp->lvalue + 2;
-			memcpy(idx, vp->strvalue, vp->lvalue);
 			idx += vp->lvalue;
 		}
 	}
@@ -466,7 +460,7 @@ static int validate_message_authenticator(VALUE_PAIR *vp, const uint8_t *recv_bu
 	/* Calculate HMAC-MD5 [RFC2104] hash */
 	uint8_t digest[MD5_DIGEST_SIZE];
 	rc_hmac_md5((uint8_t *)verify_buffer, (size_t)length + AUTH_HDR_LEN, (uint8_t *)secret, strlen(secret), digest);
-	return memcmp(received_message_authenticator, digest, 16);
+	return memcmp(received_message_authenticator, digest, MD5_DIGEST_SIZE);
 }
 
 /** Sends a request to a RADIUS server and waits for the reply

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -429,6 +429,46 @@ static int add_msg_auth_attr(rc_handle * rh, char * secret,
 	return total_length;
 }
 
+/** Validate the Message-Authenticator attribute
+ *
+ * @param vp The received a/v pairs
+ * @param recv_buffer The original packet
+ * @param length The length of the original packet
+ * @param secret The RADIUS secret
+ * @return zero on success, other values for failure
+ */
+static int validate_message_authenticator(VALUE_PAIR *vp, const uint8_t *recv_buffer, const size_t length, const char *secret) {
+	uint8_t verify_buffer[RC_BUFFER_LEN];
+	uint8_t *idx = verify_buffer + AUTH_HDR_LEN;
+	const char *received_message_authenticator = NULL;
+
+	/* Reconstruct the original packet, but fill the Message-Authenticator value with zeroes instead */
+	memset(verify_buffer, 0, sizeof(verify_buffer));
+	memcpy(verify_buffer, recv_buffer, AUTH_HDR_LEN);
+	for (; vp != NULL; vp = vp->next) {
+		*idx++ = vp->attribute;
+		if (!rc_avpair_get_uint32(vp, NULL)) {
+			*idx++ = 6;
+			const uint32_t value = ntohl(vp->lvalue);
+			memcpy(idx, &value, 4);
+			idx += 4;
+		} else if (vp->attribute == PW_MESSAGE_AUTHENTICATOR) {
+			*idx++ = vp->lvalue + 2;
+			idx += vp->lvalue;
+			received_message_authenticator = vp->strvalue;
+		} else {
+			*idx++ = vp->lvalue + 2;
+			memcpy(idx, vp->strvalue, vp->lvalue);
+			idx += vp->lvalue;
+		}
+	}
+
+	/* Calculate HMAC-MD5 [RFC2104] hash */
+	uint8_t digest[MD5_DIGEST_SIZE];
+	rc_hmac_md5((uint8_t *)verify_buffer, (size_t)length + AUTH_HDR_LEN, (uint8_t *)secret, strlen(secret), digest);
+	return memcmp(received_message_authenticator, digest, 16);
+}
+
 /** Sends a request to a RADIUS server and waits for the reply
  *
  * @param rh a handle to parsed configuration
@@ -856,57 +896,29 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 		goto cleanup;
 	}
 
-	if (msg) {
-		*msg = '\0';
-		pos = 0;
-		if ((vp = rc_avpair_get(data->receive_pairs, PW_MESSAGE_AUTHENTICATOR, 0))) {
-			uint8_t verify_buffer[RC_BUFFER_LEN];
-			uint8_t *idx = verify_buffer + AUTH_HDR_LEN;
-			char *received_message_authenticator = vp->strvalue;
-
-			memset(verify_buffer, 0, sizeof(verify_buffer));
-			memcpy(verify_buffer, recv_buffer, AUTH_HDR_LEN);
-			for (vp = data->receive_pairs; vp != NULL; vp = vp->next) {
-				*idx++ = vp->attribute;
-				if (vp->type == PW_TYPE_INTEGER || vp->type == PW_TYPE_DATE || vp->type == PW_TYPE_IPADDR) {
-					*idx++ = 6;
-					uint32_t value = htonl(vp->lvalue);
-					memcpy(idx, &value, 4);
-					idx += 4;
-				} else if (vp->attribute == PW_MESSAGE_AUTHENTICATOR) {
-					*idx++ = vp->lvalue + 2;
-					idx += vp->lvalue;
-				} else {
-					*idx++ = vp->lvalue + 2;
-					memcpy(idx, vp->strvalue, vp->lvalue);
-					idx += vp->lvalue;
-				}
-			}
-			// Copied fom add_msg_auth_attr
-			uint8_t digest[MD5_DIGEST_SIZE];
-			rc_hmac_md5((uint8_t *)verify_buffer, (size_t)length + AUTH_HDR_LEN, (uint8_t *)secret, strlen(secret), digest);
-			if (memcmp(received_message_authenticator, digest, 16)) {
-				rc_log(LOG_ERR,
-				       "rc_send_server: recvfrom: %s:%d: received attribute Message-Authenticator is incorrect",
-				       server_name, data->svc_port);
-				memset(secret, '\0', sizeof(secret));
-				result = ERROR_RC;
-				goto cleanup;
-			}
-		} else {
-			// No Message-Authenticator attribute, should use a config option to make it possible to accept
+	if (rc_avpair_get(data->receive_pairs, PW_MESSAGE_AUTHENTICATOR, 0)) {
+		if (validate_message_authenticator(data->receive_pairs, recv_buffer, length, secret)) {
 			rc_log(LOG_ERR,
-			       "rc_send_server: recvfrom: %s:%d: required attribute Message-Authenticator is missing",
-			       server_name, data->svc_port);
+						 "rc_send_server: recvfrom: %s:%d: received attribute Message-Authenticator is incorrect",
+						 server_name, data->svc_port);
 			memset(secret, '\0', sizeof(secret));
 			result = ERROR_RC;
 			goto cleanup;
 		}
+	} else {
+		// No Message-Authenticator attribute, should use a config option to make it possible to accept
+		rc_log(LOG_ERR,
+					 "rc_send_server: recvfrom: %s:%d: required attribute Message-Authenticator is missing",
+					 server_name, data->svc_port);
+		memset(secret, '\0', sizeof(secret));
+		result = ERROR_RC;
+		goto cleanup;
 	}
 
 	memset(secret, '\0', sizeof(secret));
 
 	if (msg) {
+		*msg = '\0';
 		pos = 0;
 		vp = data->receive_pairs;
 		while (vp) {

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -856,10 +856,57 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 		goto cleanup;
 	}
 
+	if (msg) {
+		*msg = '\0';
+		pos = 0;
+		if ((vp = rc_avpair_get(data->receive_pairs, PW_MESSAGE_AUTHENTICATOR, 0))) {
+			uint8_t verify_buffer[RC_BUFFER_LEN];
+			uint8_t *idx = verify_buffer + AUTH_HDR_LEN;
+			char *received_message_authenticator = vp->strvalue;
+
+			memset(verify_buffer, 0, sizeof(verify_buffer));
+			memcpy(verify_buffer, recv_buffer, AUTH_HDR_LEN);
+			for (vp = data->receive_pairs; vp != NULL; vp = vp->next) {
+				*idx++ = vp->attribute;
+				if (vp->type == PW_TYPE_INTEGER || vp->type == PW_TYPE_DATE || vp->type == PW_TYPE_IPADDR) {
+					*idx++ = 6;
+					uint32_t value = htonl(vp->lvalue);
+					memcpy(idx, &value, 4);
+					idx += 4;
+				} else if (vp->attribute == PW_MESSAGE_AUTHENTICATOR) {
+					*idx++ = vp->lvalue + 2;
+					idx += vp->lvalue;
+				} else {
+					*idx++ = vp->lvalue + 2;
+					memcpy(idx, vp->strvalue, vp->lvalue);
+					idx += vp->lvalue;
+				}
+			}
+			// Copied fom add_msg_auth_attr
+			uint8_t digest[MD5_DIGEST_SIZE];
+			rc_hmac_md5((uint8_t *)verify_buffer, (size_t)length + AUTH_HDR_LEN, (uint8_t *)secret, strlen(secret), digest);
+			if (memcmp(received_message_authenticator, digest, 16)) {
+				rc_log(LOG_ERR,
+				       "rc_send_server: recvfrom: %s:%d: received attribute Message-Authenticator is incorrect",
+				       server_name, data->svc_port);
+				memset(secret, '\0', sizeof(secret));
+				result = ERROR_RC;
+				goto cleanup;
+			}
+		} else {
+			// No Message-Authenticator attribute, should use a config option to make it possible to accept
+			rc_log(LOG_ERR,
+			       "rc_send_server: recvfrom: %s:%d: required attribute Message-Authenticator is missing",
+			       server_name, data->svc_port);
+			memset(secret, '\0', sizeof(secret));
+			result = ERROR_RC;
+			goto cleanup;
+		}
+	}
+
 	memset(secret, '\0', sizeof(secret));
 
 	if (msg) {
-		*msg = '\0';
 		pos = 0;
 		vp = data->receive_pairs;
 		while (vp) {

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -457,6 +457,11 @@ static int validate_message_authenticator(VALUE_PAIR *vp, const uint8_t *recv_bu
 		}
 	}
 
+	/* This should not happen, but it keeps clang-analyzer happy */
+	if (received_message_authenticator == NULL) {
+		return -1;
+	}
+
 	/* Calculate HMAC-MD5 [RFC2104] hash */
 	uint8_t digest[MD5_DIGEST_SIZE];
 	rc_hmac_md5((uint8_t *)verify_buffer, (size_t)length + AUTH_HDR_LEN, (uint8_t *)secret, strlen(secret), digest);

--- a/tests/raddb/users
+++ b/tests/raddb/users
@@ -11,7 +11,8 @@ test	Cleartext-Password := "test"
 	Framed-IP-Address = 192.168.1.190,
 	Framed-IP-Netmask = 255.255.255.0,
 	Framed-Routing = Broadcast-Listen,
-	Framed-MTU = 1500
+	Framed-MTU = 1500,
+	Message-Authenticator := 0x00
 
 test6	Cleartext-Password := "test"
 	Service-Type = Framed-User,


### PR DESCRIPTION
This is the sibling of #111 where the received Mesage-Authenticator attribute is required and validated. See #107 as well for a description why this should be done.

The code is a bit hacky, and uses a lot of copy-paste from existing code. I guess a few things can be done easier, but I couldn't find much in the code:
* We need a copy of the RADIUS packet, replace the Message-Authenticator attribute with nulls and calculate the checksum to see if it matches. It currently makes that copy by looping over the attributes and adding them one by one again, except if it's the Message-Authenticator attribute. This could be done with a simple combination of memcpy and memset, but I couldn't find a way to get the index of the attribute.
* The calculation of the hash is a direct copy-paste of code that creates it when sending packets, that could probably be made more generic (although this are just a few lines)
* The current behaviour is to return an error if the Message-Authenticator attribute is missing. It should probably become a config option to choose if this is an error, should be logged, or should be ignored. Not every RADIUS server replies with a Message-Authenticator attribute.