### PR TITLE
CVE-2024-3596: Validate Message-Authenticator in received responses

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
             - name: Install dependencies
               run: |
                   sudo apt-get update -qq
-                  sudo apt-get install -qq gcc freeradius libgnutls28-dev libasan5
+                  sudo apt-get install -qq gcc freeradius libgnutls28-dev libasan5 python3
             - name: Compile with address sanitizer
               run: |
                   touch config.rpath && autoreconf -fvi
@@ -64,7 +64,7 @@ jobs:
             - name: Install dependencies
               run: |
                   sudo apt-get update -qq
-                  sudo apt-get install -qq gcc freeradius libgnutls28-dev
+                  sudo apt-get install -qq gcc freeradius libgnutls28-dev python3
             - name: Compile with undefined sanitizer
               run: |
                   touch config.rpath && autoreconf -fvi
@@ -89,7 +89,7 @@ jobs:
             - name: Install dependencies
               run: |
                   sudo apt-get update -qq
-                  sudo apt-get install -qq gcc freeradius libgnutls28-dev abigail-tools
+                  sudo apt-get install -qq gcc freeradius libgnutls28-dev abigail-tools python3
             - name: Compile
               run: |
                   touch config.rpath && autoreconf -fvi

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 * Version 1.5.0 (unreleased)
-- Send Message-Authenticator message unconditionally.
+- Send Message-Authenticator message unconditionally (#107)
+- Validate the Message-Authenticator attribute in received responses.
+  Per draft-ietf-radext-deprecating-radius (CVE-2024-3596 / BLAST RADIUS),
+  servers MUST include Message-Authenticator in all Access-Request responses
+  and clients MUST discard responses that lack or fail it. Responses missing
+  the attribute are therefore rejected by default. Set
+  'require-message-authenticator = no' in the client config to allow
+  responses from legacy servers that do not include this attribute.
 - Fix reconnection to a server that has closed the TLS connection (#89)
 - Allow large attribute names in dictionaries (#77)
 

--- a/doc/man/rc_read_config.3
+++ b/doc/man/rc_read_config.3
@@ -12,12 +12,34 @@ rc_read_config \-
 );
 .fi
 .SH DESCRIPTION
-.PP 
+.PP
 Read the global config file
-.PP 
+.PP
 This function will load the provided configuration file, and any other files such as the dictionary. This is the most common mode of use of this library. The configuration format is compatible with the radiusclient-ng and freeradius-client formats.
-.PP 
+.PP
 Note: To preserve compatibility with libraries of the same API which don't load the dictionary care is taken not to reload the same filename twice even if instructed to.
+.PP
+The following string options are recognised in the configuration file:
+.TP
+.B serv-type
+Transport protocol; one of \fIudp\fP (default), \fItcp\fP, \fItls\fP, \fIdtls\fP.
+.TP
+.B tls-ca-file
+PEM file of the CA certificate used to verify the server (TLS/DTLS).
+.TP
+.B tls-cert-file
+PEM file of the client certificate (TLS/DTLS).
+.TP
+.B tls-key-file
+PEM file of the client private key (TLS/DTLS).
+.TP
+.B tls-verify-hostname
+Set to \fIfalse\fP to skip TLS server hostname verification (not recommended).
+.TP
+.B require-message-authenticator
+Set to \fIno\fP to accept responses that lack the Message-Authenticator attribute.
+Enabled by default per draft-ietf-radext-deprecating-radius (CVE-2024-3596 / BLAST RADIUS);
+only disable for legacy servers that do not send this attribute.
 .SH PARAMETERS
 .TP
 .B filename

--- a/doc/radius-test-server.md
+++ b/doc/radius-test-server.md
@@ -1,0 +1,221 @@
+# RADIUS test server (`tests/radius-server.py`)
+
+A minimal RADIUS server written in Python 3 (stdlib only) used by the test suite
+to craft responses that a real server such as FreeRADIUS would not produce.
+Currently used by `tests/msg-auth-tests.sh` to test Message-Authenticator handling.
+
+## Invocation
+
+```
+python3 tests/radius-server.py [--port PORT] [--secret SECRET] \
+                               [--msg-auth correct|absent|wrong]
+```
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--port` | 1812 | UDP port to listen on |
+| `--secret` | `testing123` | Shared secret (must match the client config) |
+| `--msg-auth` | `correct` | How to handle the Message-Authenticator attribute in the reply |
+
+The server accepts one UDP packet at a time, sends one reply, and loops forever.
+It exits when killed (SIGTERM/SIGKILL).
+
+---
+
+## RADIUS packet structure
+
+Every RADIUS packet starts with a fixed 20-byte header, followed by zero or more
+attributes encoded as type-length-value (TLV) triples:
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|     Code      | Identifier    |            Length             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
+|                     Authenticator (16)                        |
+|                                                               |
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|  Attributes ...
+```
+
+**Code** (1 byte): packet type.  Relevant codes:
+
+| Code | Name |
+|------|------|
+| 1 | Access-Request |
+| 2 | Access-Accept |
+| 3 | Access-Reject |
+| 11 | Access-Challenge |
+
+**Identifier** (1 byte): copied from the request into the reply so the client can
+match responses to requests.
+
+**Length** (2 bytes, big-endian): total packet length including the header.
+
+**Authenticator** (16 bytes): its meaning differs between request and reply (see
+below).
+
+**Attributes**: a sequence of TLVs, each structured as:
+
+```
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+|     Type      |    Length     |  Value ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+`Length` includes the two header bytes, so a 4-byte integer attribute has
+`Length = 6` (2 header + 4 value).
+
+---
+
+## The two Authenticator fields
+
+### Request Authenticator (inside Access-Request)
+
+The client fills this with 16 random bytes.  It serves as a nonce: the server
+uses it when computing the Response Authenticator and when verifying the
+Message-Authenticator sent by the client.
+
+### Response Authenticator (inside Access-Accept / Access-Reject / …)
+
+Computed by the server over the entire reply packet:
+
+```
+ResponseAuth = MD5(Code || Identifier || Length || RequestAuth || Attributes || Secret)
+```
+
+The MD5 input is the concatenation of: the reply's code, identifier, and length
+(from the reply header); the **request**'s authenticator (16 bytes); all reply
+attributes; and the shared secret.  The result is placed in bytes 4–19 of the
+reply.
+
+The client recomputes the same MD5 to verify that the response came from a server
+that knows the shared secret.
+
+In the server:
+
+```python
+def compute_response_authenticator(code, ident, length, req_auth, attrs, secret):
+    data = struct.pack('!BBH', code, ident, length) + req_auth + attrs + secret.encode()
+    return hashlib.md5(data).digest()
+```
+
+---
+
+## Message-Authenticator attribute (type 80, RFC 3579)
+
+The Message-Authenticator attribute (attribute type 80) carries an HMAC-MD5
+over the entire packet.  Its purpose is to authenticate the packet contents,
+closing an MD5-prefix attack (BLAST RADIUS / CVE-2024-3596) that is possible
+when only the Response Authenticator is used.
+
+The attribute is 18 bytes long:
+
+```
++------+------+--------------------------------------------------+
+| 0x50 | 0x12 |  HMAC-MD5 (16 bytes)                            |
++------+------+--------------------------------------------------+
+  type   len
+  (80)   (18)
+```
+
+The HMAC-MD5 is computed over the **complete** packet with the 16 value bytes of
+this attribute set to all-zeros:
+
+```
+MA = HMAC-MD5(packet_with_MA_zeroed, secret)
+```
+
+Per `draft-ietf-radext-deprecating-radius` (the BLAST RADIUS mitigation), the
+Message-Authenticator MUST be the **first** attribute in Access-Accept /
+Access-Reject / Access-Challenge replies.  radcli enforces this by checking that
+the first attribute byte is type 80 before trusting the value.
+
+In the server:
+
+```python
+def compute_hmac_md5(packet, secret):
+    return hmac.new(secret.encode(), packet, hashlib.md5).digest()
+```
+
+---
+
+## Packet construction order
+
+Building a reply involves a circular dependency: the Response Authenticator
+covers the attributes (including MA), but the MA covers the full packet
+(including the Response Authenticator).  The dependency is broken by using
+all-zeros as the MA placeholder during both computations, then filling in the
+real MA at the end:
+
+```
+1. Build reply attributes with MA value = 00 00 ... 00  (16 zero bytes)
+2. ResponseAuth = MD5(code + id + len + RequestAuth + attrs + secret)
+3. Assemble packet = header(code+id+len) + ResponseAuth + attrs
+   (MA value is still all-zeros in the assembled packet)
+4. MA = HMAC-MD5(packet, secret)   ← packet still has zero MA
+5. Write MA into packet at the known offset
+```
+
+This is why `handle_packet` builds `attrs` first, computes `resp_auth`, assembles
+the `bytearray`, and only then overwrites the MA field:
+
+```python
+# Step 1 – MA placeholder first (position check requires it to be first)
+ma_placeholder = build_ma_attr()          # type=80, len=18, value=00*16
+attrs = ma_placeholder + build_reply_attrs()
+ma_offset = 22                            # 20 (header) + 2 (type+len)
+
+# Step 2+3 – Response Authenticator and packet assembly
+resp_auth = compute_response_authenticator(ACCESS_ACCEPT, ident, total_len,
+                                           req_auth, attrs, secret)
+packet = bytearray(struct.pack('!BBH', ACCESS_ACCEPT, ident, total_len)
+                   + resp_auth + attrs)
+
+# Step 4+5 – fill in real MA (packet still has zero MA at ma_offset)
+ma_value = compute_hmac_md5(bytes(packet), secret)
+packet[ma_offset:ma_offset + MA_LEN] = ma_value
+```
+
+---
+
+## `--msg-auth` modes
+
+| Mode | What the server sends |
+|------|-----------------------|
+| `correct` | MA present, first, with valid HMAC-MD5 |
+| `absent` | No MA attribute at all |
+| `wrong` | MA present, first, but value is 16 zero bytes (invalid HMAC) |
+| `not-first` | MA present, valid HMAC-MD5, but placed after the other attributes |
+
+`wrong` is produced by skipping steps 4+5 above: the MA attribute is present in
+the packet (so the "first attribute" position check passes) but its value is
+never filled in, so the HMAC comparison in the client fails.
+
+`not-first` places the MA attribute after `build_reply_attrs()` instead of
+before it.  The HMAC is still computed correctly, so value verification passes —
+but radcli rejects the packet because `recv_buffer[AUTH_HDR_LEN]` is not type 80.
+
+---
+
+## Adding a new test scenario
+
+Typical extension points:
+
+**Different response code** (e.g. Access-Reject):  change `ACCESS_ACCEPT` to `3`
+in `handle_packet`.
+
+**Additional attributes**: add a `build_*_attr` helper following the same
+`struct.pack('!BB...', type, length, value...)` pattern, then append it in
+`build_reply_attrs`.
+
+**New `--msg-auth` mode**: add a choice to the `argparse` definition and a
+corresponding branch after the `packet` assembly in `handle_packet`.
+
+**Inspect the incoming request**: the raw request bytes are in `data`; the
+attributes start at `data[20:]` and can be walked with a `while` loop reading
+`type = data[pos]`, `length = data[pos+1]`, `value = data[pos+2:pos+length]`,
+`pos += length`.

--- a/etc/radiusclient-tls.conf.in
+++ b/etc/radiusclient-tls.conf.in
@@ -86,3 +86,9 @@ tls-key-file	@pkgsysconfdir@/key.pem
 # Used for debugging purposed. It will disable hostname verification
 # on the connected host. Not recommended to be enabled.
 #tls-verify-hostname	false
+
+# Require the Message-Authenticator attribute in received responses.
+# Mandated by draft-ietf-radext-deprecating-radius as a mitigation for
+# CVE-2024-3596 (BLAST RADIUS). Enabled by default; set to 'no' only
+# when communicating with legacy servers that do not send this attribute.
+#require-message-authenticator	no

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -72,3 +72,9 @@ bindaddr	*
 
 # To enable verbose debugging messages in syslog, enable the following
 #clientdebug 1
+
+# Require the Message-Authenticator attribute in received responses.
+# Mandated by draft-ietf-radext-deprecating-radius as a mitigation for
+# CVE-2024-3596 (BLAST RADIUS). Enabled by default; set to 'no' only
+# when communicating with legacy servers that do not send this attribute.
+#require-message-authenticator	no

--- a/lib/config.c
+++ b/lib/config.c
@@ -562,6 +562,17 @@ int rc_apply_config(rc_handle *rh)
  * which don't load the dictionary care is taken not to reload the
  * same filename twice even if instructed to.
  *
+ * The following string options are recognised in the configuration file:
+ *  - @b serv-type: transport protocol; one of 'udp' (default), 'tcp', 'tls', 'dtls'.
+ *  - @b tls-ca-file: PEM file of the CA certificate to verify the server (TLS/DTLS).
+ *  - @b tls-cert-file: PEM file of the client certificate (TLS/DTLS).
+ *  - @b tls-key-file: PEM file of the client private key (TLS/DTLS).
+ *  - @b tls-verify-hostname: set to 'false' to skip TLS server hostname verification (not recommended).
+ *  - @b require-message-authenticator: set to 'no' to accept responses that lack the
+ *    Message-Authenticator attribute. Enabled by default per
+ *    draft-ietf-radext-deprecating-radius (CVE-2024-3596 / BLAST RADIUS); only
+ *    disable for legacy servers that do not send this attribute.
+ *
  * @param filename a name of a file.
  * @return new rc_handle on success, NULL when failure.
  */

--- a/lib/options.h
+++ b/lib/options.h
@@ -35,6 +35,7 @@ static OPTION config_options_default[] = {
 {"namespace",		OT_STR, ST_UNDEF, NULL}, 
 {"use-public-addr",	OT_STR, ST_UNDEF, NULL},
 {"tls-verify-hostname",	OT_STR, ST_UNDEF, NULL},
+{"require-message-authenticator", OT_STR, ST_UNDEF, NULL}, /* default: required; set "no" for legacy servers */
 {"tls-ca-file",		OT_STR, ST_UNDEF, NULL},
 {"tls-cert-file",	OT_STR, ST_UNDEF, NULL},
 {"tls-key-file",	OT_STR, ST_UNDEF, NULL},

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -329,8 +329,8 @@ static int rc_check_reply(AUTH_HDR * auth, int bufferlen, char const *secret,
 	}
 #endif
 
-	if (memcmp((char *)reply_digest, (char *)calc_digest,
-		   AUTH_VECTOR_LEN) != 0) {
+	if (rc_memcmp((char *)reply_digest, (char *)calc_digest,
+		      AUTH_VECTOR_LEN) != 0) {
 		rc_log(LOG_ERR,
 		       "rc_check_reply: received invalid reply digest from RADIUS server");
 		return BADRESP_RC;
@@ -495,7 +495,7 @@ static int validate_message_authenticator(VALUE_PAIR *vp, const uint8_t *recv_bu
 
 	/* Calculate HMAC-MD5 [RFC2104] hash */
 	rc_hmac_md5(verify_buffer, AUTH_HDR_LEN + length, (uint8_t *)secret, strlen(secret), digest);
-	return memcmp(received_message_authenticator, digest, MD5_DIGEST_SIZE);
+	return rc_memcmp(received_message_authenticator, digest, MD5_DIGEST_SIZE);
 }
 
 /** Sends a request to a RADIUS server and waits for the reply

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -429,6 +429,75 @@ static int add_msg_auth_attr(rc_handle * rh, char * secret,
 	return total_length;
 }
 
+/** Validate the Message-Authenticator attribute
+ *
+ * @param vp The received a/v pairs
+ * @param recv_buffer The original packet
+ * @param length The length of the attribute data (packet length minus AUTH_HDR_LEN)
+ * @param secret The RADIUS secret
+ * @param req_auth The request authenticator from the Access-Request (RFC 3579 §3.2
+ *   requires MA in responses to be computed over the packet with the Request
+ *   Authenticator in the Authenticator field, not the Response Authenticator)
+ * @return zero on success, other values for failure
+ */
+static int validate_message_authenticator(VALUE_PAIR *vp, const uint8_t *recv_buffer,
+					  const size_t length, const char *secret,
+					  const unsigned char *req_auth)
+{
+	uint8_t verify_buffer[RC_BUFFER_LEN];
+	uint8_t *idx = verify_buffer + AUTH_HDR_LEN;
+	const uint8_t *verify_end = verify_buffer + sizeof(verify_buffer);
+	const char *received_message_authenticator = NULL;
+	uint8_t digest[MD5_DIGEST_SIZE];
+	unsigned attr_len;
+
+	if (AUTH_HDR_LEN + length > sizeof(verify_buffer)) {
+		rc_log(LOG_ERR, "%s: packet too large for verification buffer", __func__);
+		return -1;
+	}
+
+	/* Copy the original packet, then substitute the Request Authenticator
+	 * per RFC 3579 §3.2, and clear the Message-Authenticator value */
+	memcpy(verify_buffer, recv_buffer, AUTH_HDR_LEN + length);
+	memcpy(verify_buffer + 4, req_auth, AUTH_VECTOR_LEN);
+	for (; vp != NULL; vp = vp->next) {
+		if (vp->type == PW_TYPE_INTEGER || vp->type == PW_TYPE_DATE ||
+		    vp->type == PW_TYPE_IPADDR) {
+			attr_len = 4;
+		} else {
+			attr_len = vp->lvalue;
+		}
+
+		/* type (1) + length (1) + value */
+		if (idx + 2 + attr_len > verify_end) {
+			rc_log(LOG_ERR, "%s: attribute overflows verification buffer", __func__);
+			return -1;
+		}
+		idx += 2;
+
+		if (vp->attribute == PW_MESSAGE_AUTHENTICATOR) {
+			if (vp->lvalue != MD5_DIGEST_SIZE) {
+				rc_log(LOG_ERR, "%s: Message-Authenticator has wrong length %u",
+				       __func__, vp->lvalue);
+				return -1;
+			}
+			memset(idx, '\0', MD5_DIGEST_SIZE);
+			received_message_authenticator = vp->strvalue;
+			break;
+		} else {
+			idx += attr_len;
+		}
+	}
+
+	if (received_message_authenticator == NULL) {
+		return -1;
+	}
+
+	/* Calculate HMAC-MD5 [RFC2104] hash */
+	rc_hmac_md5(verify_buffer, AUTH_HDR_LEN + length, (uint8_t *)secret, strlen(secret), digest);
+	return memcmp(received_message_authenticator, digest, MD5_DIGEST_SIZE);
+}
+
 /** Sends a request to a RADIUS server and waits for the reply
  *
  * @param rh a handle to parsed configuration
@@ -861,6 +930,34 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 	if (result != OK_RC) {
 		memset(secret, '\0', sizeof(secret));
 		goto cleanup;
+	}
+
+	/* Per draft-ietf-radext-deprecating-radius, Message-Authenticator MUST
+	 * be the first attribute in Access-Request responses to prevent MD5
+	 * prefix attacks (BLAST RADIUS). Not required for Accounting-Response. */
+	if (type == AUTH) {
+		if (length > 0 && recv_buffer[AUTH_HDR_LEN] == PW_MESSAGE_AUTHENTICATOR &&
+		    rc_avpair_get(data->receive_pairs, PW_MESSAGE_AUTHENTICATOR, 0)) {
+
+			if (validate_message_authenticator(data->receive_pairs, recv_buffer, length, secret, vector)) {
+				rc_log(LOG_ERR,
+				       "rc_send_server: recvfrom: %s:%d: received attribute Message-Authenticator is incorrect",
+				       server_name, data->svc_port);
+				memset(secret, '\0', sizeof(secret));
+				result = ERROR_RC;
+				goto cleanup;
+			}
+		} else {
+			p = rc_conf_str(rh, "require-message-authenticator");
+			if (p == NULL || (strcasecmp(p, "false") != 0 && strcasecmp(p, "no") != 0)) {
+				rc_log(LOG_ERR,
+				       "rc_send_server: recvfrom: %s:%d: required attribute Message-Authenticator is missing or not first",
+				       server_name, data->svc_port);
+				memset(secret, '\0', sizeof(secret));
+				result = ERROR_RC;
+				goto cleanup;
+			}
+		}
 	}
 
 	memset(secret, '\0', sizeof(secret));

--- a/lib/util.h
+++ b/lib/util.h
@@ -10,6 +10,21 @@
 
 #include <string.h>
 
+#ifdef HAVE_GNUTLS
+# include <gnutls/gnutls.h>
+#endif
+
+/* Constant-time memory comparison for security-sensitive data.
+ * Uses gnutls_memcmp() when GnuTLS is available, falls back to memcmp(). */
+static inline int rc_memcmp(const void *s1, const void *s2, size_t n)
+{
+#ifdef HAVE_GNUTLS
+	return gnutls_memcmp(s1, s2, n);
+#else
+	return memcmp(s1, s2, n);
+#endif
+}
+
 #ifndef HAVE_STRLCPY
 size_t rc_strlcpy(char *dst, char const *src, size_t siz);
 # define strlcpy rc_strlcpy

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,13 +15,16 @@ EXTRA_DIST = radiusclient-ipv6.conf servers-ipv6 \
 	raddb-tcp/access_challenge raddb-tcp/access_reject \
 	raddb-tcp/accounting_response raddb-tcp/acct_users raddb-tcp/ca.pem \
 	raddb-tcp/cert-rsa.pem raddb-tcp/clients.conf raddb-tcp/key-rsa.pem \
-	raddb-tcp/radiusd.conf raddb-tcp/users ns.sh
+	raddb-tcp/radiusd.conf raddb-tcp/users \
+	radius-server.py \
+	common.sh \
+	ns.sh
 
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/src -I$(top_builddir)
 LDADD = ../lib/libradcli.la
 
-dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh tls-idle-restart-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh
-TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh
+dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh tls-idle-restart-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh msg-auth-tests.sh
+TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh msg-auth-tests.sh
 check_PROGRAMS =
 
 if ENABLE_GNUTLS

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Common utilities for radcli tests.
+
+have_port_finder() {
+	for file in $(which ss 2> /dev/null) /*bin/ss /usr/*bin/ss /usr/local/*bin/ss;do
+		if test -x "$file";then
+			PFCMD="$file";return 0
+		fi
+	done
+
+	if test -z "$PFCMD";then
+	for file in $(which netstat 2> /dev/null) /bin/netstat /usr/bin/netstat /usr/local/bin/netstat;do
+		if test -x "$file";then
+			PFCMD="$file";return 0
+		fi
+	done
+	fi
+
+	if test -z "$PFCMD";then
+		echo "neither ss nor netstat found"
+		exit 1
+	fi
+}
+
+check_if_port_in_use() {
+	local PORT="$1"
+	local PFCMD; have_port_finder
+	$PFCMD -an 2>/dev/null|grep "[\:\.]$PORT" >/dev/null 2>&1
+}
+
+# run_test DESC CMD [expect_fail]
+# Runs CMD, prints its output indented under a [ RUN ] / [ OK ] / [ FAIL ] banner.
+# Pass a non-empty third argument when a non-zero exit code is the expected outcome.
+# Returns 1 on unexpected result, 0 otherwise.  Output is captured in $TMPFILE.
+run_test() {
+	local desc="$1"
+	local expect_fail="$3"
+
+	printf "\n[ RUN  ] %s\n" "$desc"
+	printf "         \$ %s\n" "$2"
+
+	eval "$2" >$TMPFILE 2>&1
+	local rc=$?
+
+	if test -s $TMPFILE; then
+		sed 's/^/         | /' $TMPFILE
+	fi
+
+	if test -n "$expect_fail"; then
+		if test $rc = 0; then
+			printf "[ FAIL ] %s (expected failure, got success)\n" "$desc"
+			return 1
+		fi
+	else
+		if test $rc != 0; then
+			printf "[ FAIL ] %s (exit code %d)\n" "$desc" "$rc"
+			return 1
+		fi
+	fi
+
+	printf "[  OK  ] %s\n" "$desc"
+	return 0
+}
+
+# Evaluate this snippet to set PORT to a random unused port number (2000-65000).
+# Example: eval "$GETPORT"
+GETPORT='
+    rc=0
+    unset myrandom
+    while test $rc = 0; do
+        if test -n "$RANDOM"; then myrandom=$(($RANDOM + $RANDOM)); fi
+        if test -z "$myrandom"; then myrandom=$(date +%N | sed s/^0*//); fi
+        if test -z "$myrandom"; then myrandom=0; fi
+        PORT="$(((($$<<15)|$myrandom) % 63001 + 2000))"
+        check_if_port_in_use $PORT;rc=$?
+    done
+'

--- a/tests/msg-auth-tests.sh
+++ b/tests/msg-auth-tests.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Copyright (C) 2026 Nikos Mavrogiannopoulos
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "===== Message-Authenticator validation tests ====="
+echo " 1. Client rejects response missing the attr"
+echo " 2. Client accepts if require-msg-auth = no"
+echo " 3. Client rejects response with wrong MA"
+echo " 4. Client rejects MA that is correct but not first"
+echo " 5. Client accepts response with correct MA"
+echo "==================================================="
+
+if ! python3 -c '' 2>/dev/null; then
+	echo "This test requires python3"
+	exit 77
+fi
+
+. ${srcdir}/common.sh
+
+PID=$$
+TMPFILE=tmp$$.out
+RADIUSPID=""
+
+eval "$GETPORT"
+
+function finish {
+	test -n "${RADIUSPID}" && kill ${RADIUSPID} >/dev/null 2>&1
+	rm -f $TMPFILE
+	rm -f radiusclient-temp$PID.conf
+	rm -f radiusclient-no-req$PID.conf
+	rm -f servers-temp$PID
+}
+trap finish EXIT
+
+wait_for_server() {
+	local i
+	for i in 1 2 3 4 5 6 7 8; do
+		check_if_port_in_use ${PORT} && return 0
+		sleep 0.5
+	done
+	return 1
+}
+
+start_server() {
+	python3 ${srcdir}/radius-server.py \
+		--port ${PORT} --secret testing123 --msg-auth "$1" 2>/dev/null &
+	RADIUSPID=$!
+	wait_for_server
+}
+
+stop_server() {
+	if test -n "${RADIUSPID}"; then
+		kill ${RADIUSPID} >/dev/null 2>&1
+		wait ${RADIUSPID} 2>/dev/null
+		RADIUSPID=""
+	fi
+}
+
+# Build a radiusclient.conf pointing to localhost:PORT
+cat >radiusclient-temp$PID.conf <<EOF
+nas-identifier my-nas-id
+authserver  127.0.0.1:${PORT}
+acctserver  127.0.0.1:${PORT}
+servers     ./servers-temp$PID
+dictionary  ../etc/dictionary
+default_realm
+radius_timeout  5
+radius_retries  1
+bindaddr    *
+EOF
+echo "127.0.0.1/127.0.0.1	testing123" >servers-temp$PID
+
+# Test 1: server sends no Message-Authenticator; default config requires it → must fail
+start_server absent
+run_test "Reject response with absent MA (require on by default)" \
+	"../src/radiusclient -D -i -f radiusclient-temp$PID.conf User-Name=test Password=test" \
+	expect_fail || exit 1
+
+# Test 2: same server (no MA), but require-message-authenticator = no → must succeed
+cp radiusclient-temp$PID.conf radiusclient-no-req$PID.conf
+echo "require-message-authenticator	no" >> radiusclient-no-req$PID.conf
+
+run_test "Accept response with absent MA when require-message-authenticator = no" \
+	"../src/radiusclient -D -i -f radiusclient-no-req$PID.conf User-Name=test Password=test" \
+	|| exit 1
+
+grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0; then
+	echo "[ FAIL ] Expected Framed-Protocol = 'PPP' in response"
+	exit 1
+fi
+
+# Test 3: server sends a Message-Authenticator with wrong value → must fail
+stop_server
+start_server wrong
+run_test "Reject response with incorrect MA value" \
+	"../src/radiusclient -D -i -f radiusclient-temp$PID.conf User-Name=test Password=test" \
+	expect_fail || exit 1
+
+# Test 4: server sends a correct MA but not as the first attribute → must fail
+stop_server
+start_server not-first
+run_test "Reject response where MA is correct but not the first attribute" \
+	"../src/radiusclient -D -i -f radiusclient-temp$PID.conf User-Name=test Password=test" \
+	expect_fail || exit 1
+
+# Test 5: server sends a correct MA (first attribute, valid HMAC) → must succeed
+stop_server
+start_server correct
+run_test "Accept response with correct MA (valid HMAC-MD5, first attribute)" \
+	"../src/radiusclient -D -i -f radiusclient-temp$PID.conf User-Name=test Password=test" \
+	|| exit 1
+
+grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0; then
+	echo "[ FAIL ] Expected Framed-Protocol = 'PPP' in response"
+	exit 1
+fi
+
+echo ""
+exit 0

--- a/tests/ns.sh
+++ b/tests/ns.sh
@@ -20,6 +20,8 @@
 
 srcdir=${srcdir:-.}
 
+. ${srcdir}/common.sh
+
 PATH=${PATH}:/usr/sbin
 IP=$(which ip)
 RADIUSD=$(which radiusd)
@@ -28,7 +30,7 @@ if test -z "${RADIUSD}";then
 	RADIUSD=$(which freeradius)
 fi 
 
-if test -z "${RADIUSD}";then
+if test -z "${RADIUSD}" && test -z "${NO_RADIUSD}";then
 	echo "This test requires radiusd"
 	exit 77
 fi
@@ -48,27 +50,6 @@ if test "$(uname -s)" != Linux;then
 	echo "This test must be run on Linux"
 	exit 77
 fi
-
-have_port_finder() {
-	for file in $(which ss 2> /dev/null) /*bin/ss /usr/*bin/ss /usr/local/*bin/ss;do
-		if test -x "$file";then
-			PFCMD="$file";return 0
-		fi
-	done
-
-	if test -z "$PFCMD";then
-	for file in $(which netstat 2> /dev/null) /bin/netstat /usr/bin/netstat /usr/local/bin/netstat;do
-		if test -x "$file";then
-			PFCMD="$file";return 0
-		fi
-	done
-	fi
-
-	if test -z "$PFCMD";then
-		echo "neither ss nor netstat found"
-		exit 1
-	fi
-}
 
 check_if_port_listening() {
 	local PORT="$1"
@@ -182,12 +163,14 @@ if test -z "${RADDB_DIR}";then
 	RADDB_DIR="raddb"
 fi
 
-set -e
-echo ${CMDNS2} ${RADIUSD} -d ${srcdir}/${RADDB_DIR}/ -fxx -l stdout
-${CMDNS2} ${RADIUSD} -d ${srcdir}/${RADDB_DIR}/ -fxx -l stdout 2>&1 &
-RADIUSPID=$!
-set +e
+if test -z "${NO_RADIUSD}"; then
+	set -e
+	echo ${CMDNS2} ${RADIUSD} -d ${srcdir}/${RADDB_DIR}/ -fxx -l stdout
+	${CMDNS2} ${RADIUSD} -d ${srcdir}/${RADDB_DIR}/ -fxx -l stdout 2>&1 &
+	RADIUSPID=$!
+	set +e
 
-wait_for_port 1812
+	wait_for_port 1812
 
-echo "Started radius (${RADDB_DIR})"
+	echo "Started radius (${RADDB_DIR})"
+fi

--- a/tests/raddb/users
+++ b/tests/raddb/users
@@ -11,7 +11,8 @@ test	Cleartext-Password := "test"
 	Framed-IP-Address = 192.168.1.190,
 	Framed-IP-Netmask = 255.255.255.0,
 	Framed-Routing = Broadcast-Listen,
-	Framed-MTU = 1500
+	Framed-MTU = 1500,
+	Message-Authenticator := 0x00
 
 test6	Cleartext-Password := "test"
 	Service-Type = Framed-User,

--- a/tests/radius-server.py
+++ b/tests/radius-server.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Minimal RADIUS server for testing Message-Authenticator handling.
+# Sends Access-Accept responses with configurable Message-Authenticator:
+#   correct  - valid HMAC-MD5 (per RFC 3579), placed first per BLAST RADIUS spec
+#   absent   - no Message-Authenticator attribute in the response
+#   wrong    - attribute present (first) but value is all-zeros (deliberately incorrect)
+#
+# Usage:
+#   python3 radius-server.py [--port 1812] [--secret testing123] \
+#                            [--msg-auth correct|absent|wrong]
+
+import argparse
+import hashlib
+import hmac
+import socket
+import struct
+
+# RADIUS codes
+ACCESS_REQUEST = 1
+ACCESS_ACCEPT  = 2
+
+# Attribute types
+ATTR_SERVICE_TYPE        = 6   # value 2 = Framed-User
+ATTR_FRAMED_PROTOCOL     = 7   # value 1 = PPP
+ATTR_FRAMED_IP_ADDRESS   = 8
+ATTR_MESSAGE_AUTHENTICATOR = 80
+
+MA_LEN = 16  # HMAC-MD5 digest size
+
+def build_uint32_attr(attr_type, value):
+    return struct.pack('!BBL', attr_type, 6, value)
+
+def build_ipv4_attr(attr_type, addr_str):
+    parts = [int(x) for x in addr_str.split('.')]
+    return struct.pack('!BBBBBB', attr_type, 6, *parts)
+
+def build_reply_attrs():
+    attrs = b''
+    attrs += build_uint32_attr(ATTR_SERVICE_TYPE, 2)       # Framed-User
+    attrs += build_uint32_attr(ATTR_FRAMED_PROTOCOL, 1)    # PPP
+    attrs += build_ipv4_attr(ATTR_FRAMED_IP_ADDRESS, '192.168.1.190')
+    return attrs
+
+def build_ma_attr(value=None):
+    """Build a Message-Authenticator TLV (type=80, len=18, value=16 bytes)."""
+    v = value if value is not None else bytes(MA_LEN)
+    return struct.pack('!BB', ATTR_MESSAGE_AUTHENTICATOR, 2 + MA_LEN) + v
+
+def compute_response_authenticator(code, ident, length, req_auth, attrs, secret):
+    """Response Authenticator = MD5(Code+ID+Length+RequestAuth+Attrs+Secret)."""
+    data = (struct.pack('!BBH', code, ident, length) +
+            req_auth + attrs + secret.encode())
+    return hashlib.md5(data).digest()
+
+def compute_hmac_md5(packet, secret):
+    """HMAC-MD5 over the full packet (MA value must already be zeroed)."""
+    return hmac.new(secret.encode(), packet, hashlib.md5).digest()
+
+def handle_packet(data, secret, msg_auth_mode):
+    """
+    Parse an Access-Request and build an Access-Accept response.
+    Returns the response bytes, or None if the packet is not an Access-Request.
+    """
+    if len(data) < 20:
+        return None
+
+    code, ident, _pkt_len = struct.unpack('!BBH', data[:4])
+    req_auth = data[4:20]
+
+    if code != ACCESS_REQUEST:
+        return None
+
+    # Build attribute payload.  Per draft-ietf-radext-deprecating-radius,
+    # Message-Authenticator MUST be the first attribute in the response.
+    reply_attrs = build_reply_attrs()
+    if msg_auth_mode == 'absent':
+        attrs = reply_attrs
+        ma_offset = None
+    elif msg_auth_mode == 'not-first':
+        # MA is valid but placed after the other attributes (not first)
+        ma_placeholder = build_ma_attr()   # 18 bytes, value = 00..0
+        attrs = reply_attrs + ma_placeholder
+        # MA value starts at: header(20) + len(reply_attrs) + type(1) + len(1)
+        ma_offset = 20 + len(reply_attrs) + 2
+    else:
+        # correct or wrong: MA is first
+        ma_placeholder = build_ma_attr()   # 18 bytes, value = 00..0
+        attrs = ma_placeholder + reply_attrs
+        # MA value starts at: header(20) + type(1) + len(1) = offset 22
+        ma_offset = 22
+
+    total_len = 20 + len(attrs)
+
+    if msg_auth_mode in ('correct', 'not-first'):
+        # RFC 3579 §3.2: MA in responses is computed over the packet with the
+        # Request Authenticator (from the Access-Request) in the Authenticator
+        # field — NOT the Response Authenticator.  Build a scratch packet with
+        # req_auth and zeroed MA, compute the HMAC, then fill in the result.
+        scratch = bytearray(
+            struct.pack('!BBH', ACCESS_ACCEPT, ident, total_len) + req_auth + attrs)
+        ma_value = compute_hmac_md5(bytes(scratch), secret)
+        scratch[ma_offset:ma_offset + MA_LEN] = ma_value
+        attrs = bytes(scratch[20:])   # attrs now carry the real MA value
+
+    # Compute Response Authenticator over the final attributes (MA filled in)
+    resp_auth = compute_response_authenticator(
+        ACCESS_ACCEPT, ident, total_len, req_auth, attrs, secret)
+
+    # Assemble final packet with Response Authenticator in the header
+    packet = struct.pack('!BBH', ACCESS_ACCEPT, ident, total_len) + resp_auth + attrs
+    # 'wrong':  MA value stays as 16 zero bytes — deliberately incorrect
+    # 'absent': no MA attribute at all
+
+    return packet
+
+def run(port, secret, msg_auth_mode):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(('0.0.0.0', port))
+    print(f"radius-server: listening on port {port}, msg-auth={msg_auth_mode}",
+          flush=True)
+
+    while True:
+        data, addr = sock.recvfrom(4096)
+        response = handle_packet(data, secret, msg_auth_mode)
+        if response is not None:
+            sock.sendto(response, addr)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Minimal RADIUS server for Message-Authenticator testing')
+    parser.add_argument('--port', type=int, default=1812)
+    parser.add_argument('--secret', default='testing123')
+    parser.add_argument('--msg-auth', dest='msg_auth',
+                        choices=['correct', 'absent', 'wrong', 'not-first'],
+                        default='correct')
+    args = parser.parse_args()
+    run(args.port, args.secret, args.msg_auth)
+
+if __name__ == '__main__':
+    main()

--- a/tests/radiusclient.conf
+++ b/tests/radiusclient.conf
@@ -35,3 +35,9 @@ radius_retries	3
 
 # Local address from which RADIUS packets have to be sent.
 bindaddr	*
+
+# Require the Message-Authenticator attribute in received responses.
+# Mandated by draft-ietf-radext-deprecating-radius as a mitigation for
+# CVE-2024-3596 (BLAST RADIUS). Enabled by default; set to 'no' only
+# when communicating with legacy servers that do not send this attribute.
+#require-message-authenticator	no


### PR DESCRIPTION
Validate the Message-Authenticator attribute (RFC 3579 and following draft-ietf-radext-deprecating-radius-09) in received RADIUS responses: if present, verify its HMAC-MD5 against the shared secret; if absent, reject the response by default. Note that this is merely a mitigation for the BLAST-RADIUS attack; use DTLS and TLS for protection.

Introduce the 'require-message-authenticator' config option (default on) to allow legacy servers that omit the attribute.

Add tests/msg-auth-tests.sh: verifies the client rejects a response lacking Message-Authenticator with default config, and accepts it when require-message-authenticator = no.

Based on a patch by Herwin Weststrate <herwin@quarantainenet.nl>