### PR TITLE
Gracefully close TLS and DTLS sockets with an alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ m4/nls.m4
 m4/po.m4
 m4/progtest.m4
 po/
+tests/close-notify-server

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* Version 1.5.1 (unreleased)
+- Close the TLS and DTLS sessions using an alert (#127)
+
+
 * Version 1.5.0 (released 2026-04-06)
 - Send Message-Authenticator message unconditionally (#107)
 - Validate the Message-Authenticator attribute in received responses.

--- a/lib/tls.c
+++ b/lib/tls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Nikos Mavrogiannopoulos.  All rights reserved.
+ * Copyright (c) 2014-2026, Nikos Mavrogiannopoulos.  All rights reserved.
  * Copyright (c) 2015, Red Hat, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -226,12 +226,21 @@ static int cert_verify_callback(gnutls_session_t session)
 static void deinit_session(tls_int_st *ses)
 {
 	if (ses->init != 0) {
+		int ret;
 		ses->init = 0;
+		if (ses->session) {
+			/* Send close_notify before closing the socket so the peer
+			 * receives a proper TLS/DTLS shutdown alert. */
+			if (ses->sockfd != -1) {
+				do {
+					ret = gnutls_bye(ses->session, GNUTLS_SHUT_WR);
+				} while (ret == GNUTLS_E_INTERRUPTED);
+			}
+			gnutls_deinit(ses->session);
+		}
 		pthread_mutex_destroy(&ses->lock);
 		if (ses->sockfd != -1)
 			close(ses->sockfd);
-		if (ses->session)
-			gnutls_deinit(ses->session);
 	}
 }
 
@@ -739,6 +748,7 @@ int rc_init_tls(rc_handle * rh, unsigned flags)
 			gnutls_psk_free_client_credentials(st->psk_cred);
 	}
 	free(st);
+	rh->so.ptr = NULL;
 	if (ns != NULL) {
 		if(-1 == rc_reset_netns(&ns_def_hdl))
 		rc_log(LOG_ERR, "rc_send_server: namespace %s reset failed", ns);

--- a/src/radiusclient.c
+++ b/src/radiusclient.c
@@ -52,6 +52,7 @@ int
 main(int argc, char **argv)
 {
     int i, nas_port, ch, acct, server, ecount, firstline, theend;
+    int ret;
     void *rh;
     size_t len;
     VALUE_PAIR *send;
@@ -141,7 +142,8 @@ main(int argc, char **argv)
 
     if (rc_read_dictionary(rh, rc_conf_str(rh, "dictionary")) != 0) {
         fprintf(stderr, "error reading radius dictionary\n");
-        exit(2);
+        ret = 2;
+        goto exit;
     }
 
     if (server == 0) {
@@ -149,17 +151,22 @@ main(int argc, char **argv)
         for (i = 0; i < argc; i++) {
             if (rc_avpair_parse(rh, argv[i], &send) < 0) {
                 fprintf(stderr, "%s: can't parse AV pair\n", argv[i]);
-                exit(3);
+                rc_avpair_free(send);
+                ret = 3;
+                goto exit;
             }
         }
         if (eap_len > 0) {
 
             if (rc_avpair_add(rh, &send, PW_EAP_MESSAGE, eap_msg, eap_len, 0) == NULL) {
                 fprintf(stderr, "Can't add EAP-Message AV pair\n");
-                exit(3);
+                rc_avpair_free(send);
+                ret = 3;
+                goto exit;
             }
         }
-        exit(process(rh, send, acct, nas_port, info));
+        ret = process(rh, send, acct, nas_port, info);
+        goto exit;
     }
     while (1 == 1) {
         send = NULL;
@@ -204,7 +211,11 @@ main(int argc, char **argv)
 		if (cp == NULL || len == 0)
             break;
     }
-    exit(0);
+    ret = 0;
+
+ exit:
+    rc_destroy(rh);
+    exit(ret);
 }
 
 int

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,22 +23,26 @@ EXTRA_DIST = radiusclient-ipv6.conf servers-ipv6 \
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/src -I$(top_builddir)
 LDADD = ../lib/libradcli.la
 
-dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh tls-idle-restart-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh msg-auth-tests.sh
+dist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh tls-tests.sh tls-idle-restart-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh msg-auth-tests.sh close-notify-tests.sh
 TESTS = basic-tests.sh ipv6-tests.sh failover-tests.sh tcp-tests.sh eap-tests.sh no-server-file-tests.sh reject-tests.sh skip-unknown-vsa.sh namespace-tests.sh radembedded-tests.sh radembedded-dict-tests.sh ipv6-non-temp-addr-tests.sh msg-auth-tests.sh
 check_PROGRAMS =
 
 if ENABLE_GNUTLS
 ctests = avpair dict dict-add
 
-TESTS += tls-tests.sh tls-idle-restart-tests.sh $(ctests)
+TESTS += tls-tests.sh tls-idle-restart-tests.sh close-notify-tests.sh $(ctests)
 
-check_PROGRAMS += tls-restart tls-idle-restart $(ctests)
+check_PROGRAMS += tls-restart tls-idle-restart close-notify-server $(ctests)
 
 tls_restart_SOURCES = tls-restart.c
 tls_restart_LDADD = ../src/libtools.a ../lib/libradcli.la
 
 tls_idle_restart_SOURCES = tls-idle-restart.c
 tls_idle_restart_LDADD = ../src/libtools.a ../lib/libradcli.la
+
+close_notify_server_SOURCES = close-notify-server.c
+close_notify_server_LDADD = $(LIBGNUTLS_LIBS)
+close_notify_server_CFLAGS = $(LIBGNUTLS_CFLAGS)
 endif
 
 

--- a/tests/close-notify-server.c
+++ b/tests/close-notify-server.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026 Nikos Mavrogiannopoulos
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Minimal TLS/DTLS-to-UDP proxy server for close_notify testing.
+ *
+ * Acts as a TLS (TCP) or DTLS (UDP) frontend that forwards raw RADIUS packets
+ * to a plain-UDP backend (radius-server.py) and relays the response back.
+ * After one request/response exchange it waits for the client to send a
+ * TLS close_notify alert.
+ *
+ * Exit 0: close_notify received (correct behaviour after the fix).
+ * Exit 1: connection closed without close_notify (bug: gnutls_bye() missing).
+ * Exit 2: setup or handshake failure (not the bug under test).
+ *
+ * Usage:
+ *   close-notify-server [--dtls] --port PORT --backend-port PORT
+ *                       --ca CA_FILE --cert CERT_FILE --key KEY_FILE
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <gnutls/gnutls.h>
+#include <gnutls/dtls.h>
+
+#define BUF_SIZE 4096
+
+/* ------------------------------------------------------------------ */
+/* DTLS custom transport                                               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * For DTLS the listening socket is UDP (connectionless).  We call recvfrom()
+ * once to learn the client's address and buffer that first datagram, then
+ * connect() the socket so that subsequent send()/recv() work normally.
+ * GnuTLS calls our pull function before the handshake to read that first
+ * datagram, so we serve it from the buffer on the first call.
+ */
+typedef struct {
+	int fd;
+	uint8_t first_buf[BUF_SIZE];
+	ssize_t first_len;	/* >= 0: unconsumed; -1: already consumed */
+} udp_tr_t;
+
+static ssize_t
+udp_push(gnutls_transport_ptr_t ptr, const void *buf, size_t len)
+{
+	udp_tr_t *t = ptr;
+	return send(t->fd, buf, len, 0);
+}
+
+static ssize_t
+udp_pull(gnutls_transport_ptr_t ptr, void *buf, size_t len)
+{
+	udp_tr_t *t = ptr;
+	if (t->first_len >= 0) {
+		ssize_t n = t->first_len < (ssize_t)len
+		            ? t->first_len : (ssize_t)len;
+		memcpy(buf, t->first_buf, n);
+		t->first_len = -1;
+		return n;
+	}
+	return recv(t->fd, buf, len, 0);
+}
+
+static int
+udp_pull_timeout(gnutls_transport_ptr_t ptr, unsigned ms)
+{
+	udp_tr_t *t = ptr;
+	fd_set fds;
+	struct timeval tv;
+
+	if (t->first_len >= 0)
+		return 1;	/* data buffered, immediately available */
+
+	FD_ZERO(&fds);
+	FD_SET(t->fd, &fds);
+
+	if (ms == GNUTLS_INDEFINITE_TIMEOUT)
+		return select(t->fd + 1, &fds, NULL, NULL, NULL);
+
+	tv.tv_sec  = ms / 1000;
+	tv.tv_usec = (ms % 1000) * 1000;
+	return select(t->fd + 1, &fds, NULL, NULL, &tv);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+static struct option longopts[] = {
+	{ "dtls",         no_argument,       NULL, 'd' },
+	{ "port",         required_argument, NULL, 'p' },
+	{ "backend-port", required_argument, NULL, 'b' },
+	{ "ca",           required_argument, NULL, 'a' },
+	{ "cert",         required_argument, NULL, 'c' },
+	{ "key",          required_argument, NULL, 'k' },
+	{ NULL, 0, NULL, 0 }
+};
+
+int main(int argc, char **argv)
+{
+	int dtls = 0, port = 0, backend_port = 0;
+	const char *ca = NULL, *cert = NULL, *key = NULL;
+	int opt, ret;
+
+	while ((opt = getopt_long(argc, argv, "dp:b:a:c:k:", longopts,
+				  NULL)) != -1) {
+		switch (opt) {
+		case 'd': dtls = 1; break;
+		case 'p': port = atoi(optarg); break;
+		case 'b': backend_port = atoi(optarg); break;
+		case 'a': ca = optarg; break;
+		case 'c': cert = optarg; break;
+		case 'k': key = optarg; break;
+		default:
+			fprintf(stderr,
+				"Usage: close-notify-server [--dtls] "
+				"--port P --backend-port P "
+				"--ca F --cert F --key F\n");
+			return 2;
+		}
+	}
+
+	if (!port || !backend_port || !ca || !cert || !key) {
+		fprintf(stderr,
+			"close-notify-server: missing required arguments\n");
+		return 2;
+	}
+
+	gnutls_global_init();
+
+	/* -- credentials (shared by TLS and DTLS) -- */
+	gnutls_certificate_credentials_t cred;
+	gnutls_certificate_allocate_credentials(&cred);
+
+	ret = gnutls_certificate_set_x509_trust_file(cred, ca,
+						     GNUTLS_X509_FMT_PEM);
+	if (ret < 0) {
+		fprintf(stderr, "close-notify-server: ca: %s\n",
+			gnutls_strerror(ret));
+		return 2;
+	}
+
+	ret = gnutls_certificate_set_x509_key_file(cred, cert, key,
+						   GNUTLS_X509_FMT_PEM);
+	if (ret < 0) {
+		fprintf(stderr, "close-notify-server: cert/key: %s\n",
+			gnutls_strerror(ret));
+		return 2;
+	}
+
+	/* -- listening socket -- */
+	int type = dtls ? SOCK_DGRAM : SOCK_STREAM;
+	int fd = socket(AF_INET, type, 0);
+	if (fd < 0) { perror("socket"); return 2; }
+
+	int on = 1;
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+	struct sockaddr_in saddr = {
+		.sin_family      = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+		.sin_port        = htons(port),
+	};
+	if (bind(fd, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
+		perror("bind"); return 2;
+	}
+
+	/* Print the actual port so the shell script can detect startup */
+	socklen_t slen = sizeof(saddr);
+	getsockname(fd, (struct sockaddr *)&saddr, &slen);
+	printf("PORT %d\n", ntohs(saddr.sin_port));
+	fflush(stdout);
+
+	/* -- accept / connect -- */
+	gnutls_session_t session;
+	udp_tr_t tr;
+	int conn_fd = -1;
+
+	if (dtls) {
+		/* Receive first datagram to learn client address */
+		struct sockaddr_in caddr;
+		socklen_t clen = sizeof(caddr);
+		tr.fd = fd;
+		tr.first_len = recvfrom(fd, tr.first_buf, sizeof(tr.first_buf),
+					0, (struct sockaddr *)&caddr, &clen);
+		if (tr.first_len < 0) { perror("recvfrom"); return 2; }
+
+		/* Connect so send()/recv() are addressed to this client */
+		if (connect(fd, (struct sockaddr *)&caddr, clen) < 0) {
+			perror("connect"); return 2;
+		}
+
+		gnutls_init(&session, GNUTLS_SERVER | GNUTLS_DATAGRAM);
+		gnutls_transport_set_ptr(session, &tr);
+		gnutls_transport_set_push_function(session, udp_push);
+		gnutls_transport_set_pull_function(session, udp_pull);
+		gnutls_transport_set_pull_timeout_function(session,
+							   udp_pull_timeout);
+		gnutls_dtls_set_timeouts(session, 100, 10000);
+	} else {
+		if (listen(fd, 1) < 0) { perror("listen"); return 2; }
+
+		conn_fd = accept(fd, NULL, NULL);
+		if (conn_fd < 0) { perror("accept"); return 2; }
+
+		gnutls_init(&session, GNUTLS_SERVER);
+		gnutls_transport_set_int(session, conn_fd);
+	}
+
+	gnutls_credentials_set(session, GNUTLS_CRD_CERTIFICATE, cred);
+	gnutls_certificate_server_set_request(session, GNUTLS_CERT_REQUIRE);
+	gnutls_set_default_priority(session);
+
+	/* -- handshake -- */
+	do {
+		ret = gnutls_handshake(session);
+	} while (ret < 0 && !gnutls_error_is_fatal(ret));
+
+	if (ret < 0) {
+		fprintf(stderr, "close-notify-server: handshake: %s\n",
+			gnutls_strerror(ret));
+		gnutls_deinit(session);
+		gnutls_certificate_free_credentials(cred);
+		if (conn_fd >= 0) close(conn_fd);
+		close(fd);
+		return 2;
+	}
+
+	/* -- proxy: one RADIUS request/response round-trip -- */
+	uint8_t req[BUF_SIZE], resp[BUF_SIZE];
+
+	int n = gnutls_record_recv(session, req, sizeof(req));
+	if (n <= 0) {
+		fprintf(stderr, "close-notify-server: recv request: %s\n",
+			n < 0 ? gnutls_strerror(n) : "empty");
+		gnutls_deinit(session);
+		gnutls_certificate_free_credentials(cred);
+		if (conn_fd >= 0) close(conn_fd);
+		close(fd);
+		return 2;
+	}
+
+	/* Forward to radius-server.py over plain UDP */
+	int udpfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (udpfd < 0) { perror("udp socket"); return 2; }
+
+	struct sockaddr_in beaddr = {
+		.sin_family      = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+		.sin_port        = htons(backend_port),
+	};
+	if (connect(udpfd, (struct sockaddr *)&beaddr, sizeof(beaddr)) < 0) {
+		perror("connect backend"); return 2;
+	}
+
+	if (send(udpfd, req, n, 0) < 0) {
+		perror("send to backend"); return 2;
+	}
+
+	/* Wait for response from radius-server.py (5 second timeout) */
+	fd_set rfds;
+	struct timeval tv = { 5, 0 };
+	FD_ZERO(&rfds);
+	FD_SET(udpfd, &rfds);
+	if (select(udpfd + 1, &rfds, NULL, NULL, &tv) <= 0) {
+		fprintf(stderr, "close-notify-server: backend timeout\n");
+		return 2;
+	}
+	int m = recv(udpfd, resp, sizeof(resp), 0);
+	if (m <= 0) {
+		fprintf(stderr, "close-notify-server: backend recv failed\n");
+		return 2;
+	}
+	close(udpfd);
+
+	ret = gnutls_record_send(session, resp, m);
+	if (ret < 0) {
+		fprintf(stderr, "close-notify-server: send response: %s\n",
+			gnutls_strerror(ret));
+		gnutls_deinit(session);
+		gnutls_certificate_free_credentials(cred);
+		if (conn_fd >= 0) close(conn_fd);
+		close(fd);
+		return 2;
+	}
+
+	/*
+	 * Wait for TLS close_notify from the client (2-second window).
+	 *
+	 * gnutls_record_recv() returns:
+	 *   0                          — close_notify received (correct)
+	 *   GNUTLS_E_PREMATURE_TERMINATION — TCP closed without close_notify
+	 *   GNUTLS_E_TIMEDOUT          — DTLS: client vanished without close_notify
+	 */
+	gnutls_record_set_timeout(session, 2000);
+	uint8_t dummy[1];
+	ret = gnutls_record_recv(session, dummy, sizeof(dummy));
+
+	int exit_code;
+	if (ret == 0) {
+		printf("PASS: close_notify received\n");
+		exit_code = 0;
+	} else {
+		printf("FAIL: expected close_notify, got: %s\n",
+		       gnutls_strerror(ret));
+		exit_code = 1;
+	}
+	fflush(stdout);
+
+	gnutls_deinit(session);
+	gnutls_certificate_free_credentials(cred);
+	gnutls_global_deinit();
+	if (conn_fd >= 0) close(conn_fd);
+	close(fd);
+	return exit_code;
+}

--- a/tests/close-notify-tests.sh
+++ b/tests/close-notify-tests.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+# Copyright (C) 2026 Nikos Mavrogiannopoulos
+#
+#   All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions
+#   are met:
+#   1. Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#   2. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#   THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+#   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#   ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+#   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+#   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+#   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+#   SUCH DAMAGE.
+
+# Test that rc_destroy() sends TLS and DTLS close_notify alerts.
+#
+# Architecture:
+#   radcli client <--TLS/DTLS--> close-notify-server <--UDP--> radius-server.py
+#
+# close-notify-server exits 0 if close_notify was received after the
+# exchange, 1 if not (bug: deinit_session() missing gnutls_bye()).
+# Does not require root; uses loopback addresses only.
+
+srcdir="${srcdir:-.}"
+
+if ! python3 -c '' 2>/dev/null; then
+	echo "This test requires python3"
+	exit 77
+fi
+
+. ${srcdir}/common.sh
+
+echo "===== TLS/DTLS close_notify tests ====="
+
+PID=$$
+TMPFILE="tmp-cn-$PID.out"
+BEPID=""
+SRVPID=""
+SERVERS_FILE="servers-cn-$PID"
+TLS_CONF="conf-tls-cn-$PID"
+DTLS_CONF="conf-dtls-cn-$PID"
+
+function finish {
+	test -n "${SRVPID}" && kill ${SRVPID} >/dev/null 2>&1
+	test -n "${BEPID}"  && kill ${BEPID}  >/dev/null 2>&1
+	rm -f "$TMPFILE" "$SERVERS_FILE" "$TLS_CONF" "$DTLS_CONF"
+}
+trap finish EXIT
+
+wait_for_server() {
+	local i
+	for i in 1 2 3 4 5 6 7 8; do
+		check_if_port_in_use ${PORT} && return 0
+		sleep 0.5
+	done
+	return 1
+}
+
+# Start radius-server.py once; reused as plain-UDP backend for both modes.
+eval "$GETPORT"
+BEPORT=${PORT}
+python3 "${srcdir}/radius-server.py" \
+	--port "${BEPORT}" --secret testing123 --msg-auth correct \
+	>/dev/null 2>&1 &
+BEPID=$!
+wait_for_server || { echo "FAIL: radius-server.py did not start"; exit 1; }
+
+# Common servers file (address must match authserver; secret ignored for TLS/DTLS).
+echo "127.0.0.1/127.0.0.1	testing123" >"${SERVERS_FILE}"
+
+# write_conf MODE PORT — writes conf-{MODE}-cn-$PID
+write_conf() {
+	local mode="$1"
+	local frontend_port="$2"
+	cat >"conf-${mode}-cn-${PID}" <<EOF
+serv-type         ${mode}
+tls-ca-file       ${srcdir}/dtls/ca.pem
+tls-cert-file     ${srcdir}/dtls/clicert.pem
+tls-key-file      ${srcdir}/dtls/clikey.pem
+tls-verify-hostname false
+authserver        127.0.0.1:${frontend_port}
+acctserver        127.0.0.1:${frontend_port}
+servers           ${SERVERS_FILE}
+dictionary        ${srcdir}/../etc/dictionary
+radius_timeout    5
+radius_retries    1
+bindaddr          *
+EOF
+}
+
+# run_test MODE — returns 0 on pass, 1 on fail
+run_close_notify_test() {
+	local mode="$1"
+	local dtls_flag=""
+	test "${mode}" = "dtls" && dtls_flag="--dtls"
+
+	eval "$GETPORT"
+	local frontend_port=${PORT}
+	write_conf "${mode}" "${frontend_port}"
+
+	./close-notify-server ${dtls_flag} \
+		--port "${frontend_port}" \
+		--backend-port "${BEPORT}" \
+		--ca  "${srcdir}/dtls/ca.pem" \
+		--cert "${srcdir}/raddb/cert-rsa.pem" \
+		--key  "${srcdir}/raddb/key-rsa.pem" \
+		>"${TMPFILE}" 2>&1 &
+	SRVPID=$!
+
+	wait_for_server || {
+		echo "FAIL: ${mode} close-notify-server did not start"
+		kill ${SRVPID} 2>/dev/null; SRVPID=""
+		return 1
+	}
+
+	../src/radiusclient -D -i \
+		-f "conf-${mode}-cn-${PID}" \
+		User-Name=test Password=test >/dev/null
+
+	wait ${SRVPID}
+	local srv_ret=$?
+	SRVPID=""
+
+	if test ${srv_ret} -ne 0; then
+		cat "${TMPFILE}"
+		return 1
+	fi
+	return 0
+}
+
+run_close_notify_test tls
+if test $? -ne 0; then
+	echo "FAIL: TLS close_notify not sent (deinit_session() missing gnutls_bye())"
+	exit 1
+fi
+echo "[  OK  ] TLS: close_notify sent correctly"
+
+run_close_notify_test dtls
+if test $? -ne 0; then
+	echo "FAIL: DTLS close_notify not sent (deinit_session() missing gnutls_bye())"
+	exit 1
+fi
+echo "[  OK  ] DTLS: close_notify sent correctly"
+
+echo ""
+exit 0


### PR DESCRIPTION
This adds gnutls_bye() as part of *TLS deinit and adds tests that validate that the session is properly closed.

Resolves: #127