### PR TITLE
avpair: reject VSA string values longer than AUTH_STRING_LEN - VSA_HDR_LEN

### DIFF
--- a/include/includes.h
+++ b/include/includes.h
@@ -159,6 +159,11 @@ int sigprocmask (int, sigset_t *, sigset_t *);
 
 #define GETSTR_LENGTH		128	//!< must be bigger than AUTH_PASS_LEN.
 
+/* Overhead consumed by the VSA envelope inside a RADIUS attribute:
+ * vendor-id(4) + sub-attr-type(1) + sub-attr-length(1) = 6 bytes.
+ * A VSA value may be at most AUTH_STRING_LEN - VSA_HDR_LEN bytes long. */
+#define VSA_HDR_LEN		6
+
 typedef struct pw_auth_hdr
 {
 	uint8_t		code;

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -140,7 +140,10 @@ int rc_avpair_assign (VALUE_PAIR *vp, void const *pval, int len)
 		case PW_TYPE_STRING:
 			if (len == -1)
 				len = (uint32_t)strlen((char const *)pval);
-			if (len > AUTH_STRING_LEN) {
+			/* Vendor-specific attributes use additionally 6 bytes of envelope
+			 * (4 vendor-id + 1 sub-type + 1 sub-length) thus reduce the AUTH_STRING_LEN
+			 * (253-byte value) to 247. */
+			if (len > (int)(VENDOR(vp->attribute) ? (AUTH_STRING_LEN - VSA_HDR_LEN) : (AUTH_STRING_LEN))) {
 		        	rc_log(LOG_ERR, "rc_avpair_assign: bad attribute length");
 		        	return -1;
 			}

--- a/tests/avpair.c
+++ b/tests/avpair.c
@@ -267,6 +267,51 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 	rc_avpair_free(send);
+
+	/* VSA length boundary: Agent-Circuit-Id (DSL-Forum vendor 3561, attr 1).
+	 * Max VSA string = AUTH_STRING_LEN - VSA_HDR_LEN = 247 bytes. */
+	{
+		char buf[254];
+		VALUE_PAIR *vp_vsa;
+
+		memset(buf, 'A', sizeof(buf));
+
+		/* 247 bytes: must succeed */
+		vp_vsa = NULL;
+		vp_vsa = rc_avpair_add(rh, &vp_vsa, 1, buf, 247, 3561);
+		if (vp_vsa == NULL) {
+			fprintf(stderr, "%d: VSA assign of 247 bytes failed (expected success)\n", __LINE__);
+			exit(1);
+		}
+		rc_avpair_free(vp_vsa);
+
+		/* 248 bytes: must fail */
+		vp_vsa = NULL;
+		vp_vsa = rc_avpair_add(rh, &vp_vsa, 1, buf, 248, 3561);
+		if (vp_vsa != NULL) {
+			fprintf(stderr, "%d: VSA assign of 248 bytes succeeded (expected failure)\n", __LINE__);
+			rc_avpair_free(vp_vsa);
+			exit(1);
+		}
+
+		/* Standard attr: 253 bytes must succeed, 254 must fail */
+		vp_vsa = NULL;
+		vp_vsa = rc_avpair_add(rh, &vp_vsa, PW_USER_NAME, buf, 253, 0);
+		if (vp_vsa == NULL) {
+			fprintf(stderr, "%d: standard attr assign of 253 bytes failed (expected success)\n", __LINE__);
+			exit(1);
+		}
+		rc_avpair_free(vp_vsa);
+
+		vp_vsa = NULL;
+		vp_vsa = rc_avpair_add(rh, &vp_vsa, PW_USER_NAME, buf, 254, 0);
+		if (vp_vsa != NULL) {
+			fprintf(stderr, "%d: standard attr assign of 254 bytes succeeded (expected failure)\n", __LINE__);
+			rc_avpair_free(vp_vsa);
+			exit(1);
+		}
+	}
+
 	rc_destroy(rh);
 
 	return 0;


### PR DESCRIPTION
Values of 248-253 bytes overflow the 1-byte VSA length field when packed, producing malformed RADIUS packets. Add boundary tests to tests/avpair.c.