### PR TITLE
tls: defer TCP connect and TLS handshake to first use

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+* Version 1.5.2 (unreleased)
+- tls: defer TCP connect and TLS handshake to first use. This addresses
+  the issue of radcli connecting to TLS server during rc_read_config().
+
+
 * Version 1.5.1 (released 2026-05-01)
 - Close the TLS and DTLS sessions using an alert (#127)
 - Enforce the RFC 2865 packet size limit (4096 bytes) when packing

--- a/lib/tls.c
+++ b/lib/tls.c
@@ -79,6 +79,10 @@ static int restart_session(rc_handle *rh, tls_st *st);
 static int tls_get_fd(void *ptr, struct sockaddr *our_sockaddr)
 {
 	tls_st *st = ptr;
+	if (st->ctx.need_restart != 0) {
+		if (restart_session(st->rh, st) < 0)
+			return -1;
+	}
 	return st->ctx.sockfd;
 }
 
@@ -719,11 +723,13 @@ int rc_init_tls(rc_handle * rh, unsigned flags)
 		}
 	}
 
-	ret = init_session(rh, &st->ctx, hostname, port, &our_sockaddr, 0, flags);
-	if (ret < 0) {
-		ret = -1;
-		goto cleanup;
-	}
+	/* Defer TCP connect + TLS handshake to first use.
+	 * tls_sendto() checks need_restart != 0 and calls restart_session(),
+	 * which calls init_session() with these stored parameters. */
+	strlcpy(st->ctx.hostname, hostname, sizeof(st->ctx.hostname));
+	st->ctx.port = port;
+	memcpy(&st->ctx.our_sockaddr, &our_sockaddr, sizeof(our_sockaddr));
+	st->ctx.need_restart = 1;
 
 	rh->so.get_fd = tls_get_fd;
 	rh->so.get_active_fd = tls_get_active_fd;
@@ -734,6 +740,7 @@ int rc_init_tls(rc_handle * rh, unsigned flags)
 	if (ns != NULL) {
 		if(-1 == rc_reset_netns(&ns_def_hdl)) {
 			rc_log(LOG_ERR, "rc_send_server: namespace %s reset failed", ns);
+			ret = -1;
 			goto cleanup;
 		}
 	}

--- a/tests/tls-restart.c
+++ b/tests/tls-restart.c
@@ -158,25 +158,41 @@ int process(void *rh, VALUE_PAIR * send, int acct, int nas_port)
 	char buf[BUF_LEN];
 	int i, fd;
 
-	fd = rc_tls_fd(rh);
-	if (fd >= 0) {
-		if (dup(fd) == -1) {
-			fprintf(stderr, "tls-restart: dup failed %s", strerror(errno));
-			return 1; 
-		}
-		close(fd);
-	}
-
 	received = NULL;
 	if (acct == 0) {
+		/* First auth establishes the TLS session (eagerly or lazily). */
 		i = rc_auth(rh, nas_port, send, &received, msg);
 		if (i != OK_RC) {
-			fprintf(stderr, "tls-restart: error sending 1 (ok)\n");
+			fprintf(stderr, "tls-restart: error sending 1\n");
+			rc_avpair_free(received);
+			return 1;
+		}
+		rc_avpair_free(received);
+		received = NULL;
+
+		/* Close the fd underneath GnuTLS to simulate a broken session. */
+		fd = rc_tls_fd(rh);
+		if (fd >= 0) {
+			if (dup(fd) == -1) {
+				fprintf(stderr, "tls-restart: dup failed %s\n", strerror(errno));
+				return 1;
+			}
+			close(fd);
 		}
 
+		/* This auth will fail because the fd was closed; it arms
+		 * need_restart so the following attempt can reconnect. */
+		i = rc_auth(rh, nas_port, send, &received, msg);
+		rc_avpair_free(received);
+		received = NULL;
+		if (i != OK_RC) {
+			fprintf(stderr, "tls-restart: error sending 2 (ok)\n");
+		}
+
+		/* This auth must succeed via reconnection. */
 		i = rc_auth(rh, nas_port, send, &received, msg);
 		if (i != OK_RC) {
-			fprintf(stderr, "tls-restart: error sending 2\n");
+			fprintf(stderr, "tls-restart: error sending 3\n");
 			exit(2);
 		}
 		if (received != NULL) {


### PR DESCRIPTION
rc_init_tls() called init_session() directly, which performs connect() and gnutls_handshake() synchronously inside rc_read_config(). This caused ocserv vhost initialization to fail when the RADIUS server was temporarily unreachable at startup (ocserv#615).

The fix stores hostname, port, and bind address in st->ctx and sets need_restart=1, deferring the live connection to the first tls_sendto() call.