### PR TITLE
Add rc_acct_async(): non-blocking accounting broadcast to server(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tests/close-notify-server
 .html.stamp
 doc/stamp_html
 tests/pack
+tests/__pycache__/

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,12 @@
   buffer-space estimate assumed a fixed 32-byte name field while names
   can be up to 64 bytes, and the unbounded sprintf() wrote past the
   caller-supplied buffer.
+- Added rc_acct_async(): sends an accounting request to every configured
+  accounting server without waiting for a reply, for best-effort
+  notifications (e.g. an Accounting-Stop sent while an application is
+  shutting down and cannot afford to block on network I/O). Unlike
+  rc_acct(), which stops at the first server that replies, this addresses
+  all configured servers unconditionally.
 
 
 * Version 1.5.2 (released 2026-06-07)

--- a/devel/ABI-x86_64.dump
+++ b/devel/ABI-x86_64.dump
@@ -12,6 +12,7 @@
     <elf-symbol name='rc_aaa_ctx_get_vector' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='rc_aaa_ctx_server' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='rc_acct' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='rc_acct_async' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='rc_acct_proxy' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='rc_add_config' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='rc_apply_config' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -70,6 +71,7 @@
     <elf-symbol name='rc_tls_fd' version='RADCLI_10' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <undefined-elf-function-symbols>
+    <elf-symbol name='__assert_fail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='__ctype_b_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='__cxa_finalize' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='__errno_location' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
@@ -95,6 +97,7 @@
     <elf-symbol name='gmtime_r' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_alert_get' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_alert_get_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
+    <elf-symbol name='gnutls_bye' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_certificate_allocate_credentials' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_certificate_free_credentials' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_certificate_set_verify_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
@@ -113,6 +116,7 @@
     <elf-symbol name='gnutls_heartbeat_enable' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_heartbeat_ping' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
+    <elf-symbol name='gnutls_memcmp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_priority_set_direct' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_psk_allocate_client_credentials' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='gnutls_psk_free_client_credentials' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
@@ -158,10 +162,8 @@
     <elf-symbol name='sprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='srandom' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='strcasecmp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
-    <elf-symbol name='strcat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='strchr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='strcmp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
-    <elf-symbol name='strcpy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='strcspn' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='strdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
@@ -250,9 +252,9 @@
         <var-decl name='tm_zone' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_tm.h' line='21' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='DICT_ATTR' type-id='type-id-13' size-in-bits='768' filepath='../include/radcli/radcli.h' line='439' column='1' id='type-id-14'/>
-    <typedef-decl name='DICT_VALUE' type-id='type-id-15' size-in-bits='1152' filepath='../include/radcli/radcli.h' line='447' column='1' id='type-id-16'/>
-    <typedef-decl name='DICT_VENDOR' type-id='type-id-17' size-in-bits='640' filepath='../include/radcli/radcli.h' line='454' column='1' id='type-id-18'/>
+    <typedef-decl name='DICT_ATTR' type-id='type-id-13' size-in-bits='768' filepath='../include/radcli/radcli.h' line='440' column='1' id='type-id-14'/>
+    <typedef-decl name='DICT_VALUE' type-id='type-id-15' size-in-bits='1152' filepath='../include/radcli/radcli.h' line='448' column='1' id='type-id-16'/>
+    <typedef-decl name='DICT_VENDOR' type-id='type-id-17' size-in-bits='640' filepath='../include/radcli/radcli.h' line='455' column='1' id='type-id-18'/>
     <typedef-decl name='__time_t' type-id='type-id-12' size-in-bits='64' filepath='/usr/include/bits/types.h' line='160' column='1' hash='b119fe0931d2ee10' id='type-id-19'/>
     <typedef-decl name='in_addr_t' type-id='type-id-20' size-in-bits='32' filepath='/usr/include/netinet/in.h' line='30' column='1' hash='e66b43f97c38e87a' id='type-id-9'/>
     <typedef-decl name='time_t' type-id='type-id-19' size-in-bits='64' filepath='/usr/include/bits/types/time_t.h' line='10' column='1' hash='b119fe0931d2ee10' id='type-id-21'/>
@@ -310,7 +312,7 @@
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='rc_avpair_next' mangled-name='rc_avpair_next' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_next@@RADCLI_10' hash='452119daab2eac4c'>
-      <parameter type-id='type-id-53' name='p' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='450' column='1'/>
+      <parameter type-id='type-id-53' name='p' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='506' column='1'/>
       <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='rc_avpair_assign' mangled-name='rc_avpair_assign' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_assign@@RADCLI_10' hash='cdddf26064be7c2c'>
@@ -319,85 +321,85 @@
       <parameter type-id='type-id-11' name='len' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='135' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_avpair_new' mangled-name='rc_avpair_new' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_new@@RADCLI_10' hash='bd8dad0450d8ba6c'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='193' column='1'/>
-      <parameter type-id='type-id-20' name='attrid' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='193' column='1'/>
-      <parameter type-id='type-id-3' name='pval' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='193' column='1'/>
-      <parameter type-id='type-id-11' name='len' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='193' column='1'/>
-      <parameter type-id='type-id-20' name='vendorspec' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='193' column='1'/>
+    <function-decl name='rc_avpair_new' mangled-name='rc_avpair_new' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='196' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_new@@RADCLI_10' hash='bd8dad0450d8ba6c'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='196' column='1'/>
+      <parameter type-id='type-id-20' name='attrid' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='196' column='1'/>
+      <parameter type-id='type-id-3' name='pval' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='196' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='196' column='1'/>
+      <parameter type-id='type-id-20' name='vendorspec' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='196' column='1'/>
       <return type-id='type-id-53'/>
     </function-decl>
-    <function-decl name='rc_avpair_gen' mangled-name='rc_avpair_gen' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_gen@@RADCLI_10' hash='f151ba58f34057b2'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='271' column='1'/>
-      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='271' column='1'/>
-      <parameter type-id='type-id-54' name='ptr' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='271' column='1'/>
-      <parameter type-id='type-id-11' name='length' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='272' column='1'/>
-      <parameter type-id='type-id-20' name='vendorspec' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='272' column='1'/>
+    <function-decl name='rc_avpair_gen' mangled-name='rc_avpair_gen' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='468' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_gen@@RADCLI_10' hash='f151ba58f34057b2'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='468' column='1'/>
+      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='468' column='1'/>
+      <parameter type-id='type-id-54' name='ptr' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='469' column='1'/>
+      <parameter type-id='type-id-11' name='length' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='469' column='1'/>
+      <parameter type-id='type-id-20' name='vendorspec' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='470' column='1'/>
       <return type-id='type-id-53'/>
     </function-decl>
-    <function-decl name='rc_avpair_get' mangled-name='rc_avpair_get' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get@@RADCLI_10' hash='a300cfa616e69187'>
-      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='433' column='1'/>
-      <parameter type-id='type-id-20' name='attrid' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='433' column='1'/>
-      <parameter type-id='type-id-20' name='vendorspec' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='433' column='1'/>
+    <function-decl name='rc_avpair_get' mangled-name='rc_avpair_get' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='489' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get@@RADCLI_10' hash='a300cfa616e69187'>
+      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='489' column='1'/>
+      <parameter type-id='type-id-20' name='attrid' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='489' column='1'/>
+      <parameter type-id='type-id-20' name='vendorspec' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='489' column='1'/>
       <return type-id='type-id-53'/>
     </function-decl>
-    <function-decl name='rc_avpair_copy' mangled-name='rc_avpair_copy' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='450' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_copy@@RADCLI_10' hash='452119daab2eac4c'>
-      <parameter type-id='type-id-53' name='p' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='450' column='1'/>
+    <function-decl name='rc_avpair_copy' mangled-name='rc_avpair_copy' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='506' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_copy@@RADCLI_10' hash='452119daab2eac4c'>
+      <parameter type-id='type-id-53' name='p' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='506' column='1'/>
       <return type-id='type-id-53'/>
     </function-decl>
-    <function-decl name='rc_avpair_insert' mangled-name='rc_avpair_insert' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_insert@@RADCLI_10' hash='ff43e876a395514d'>
-      <parameter type-id='type-id-52' name='a' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='485' column='1'/>
-      <parameter type-id='type-id-53' name='p' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='485' column='1'/>
-      <parameter type-id='type-id-53' name='b' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='485' column='1'/>
+    <function-decl name='rc_avpair_insert' mangled-name='rc_avpair_insert' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_insert@@RADCLI_10' hash='ff43e876a395514d'>
+      <parameter type-id='type-id-52' name='a' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='541' column='1'/>
+      <parameter type-id='type-id-53' name='p' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='541' column='1'/>
+      <parameter type-id='type-id-53' name='b' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='541' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='rc_avpair_free' mangled-name='rc_avpair_free' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_free@@RADCLI_10' hash='a635386af7ae3ebb'>
-      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='537' column='1'/>
+    <function-decl name='rc_avpair_free' mangled-name='rc_avpair_free' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='593' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_free@@RADCLI_10' hash='a635386af7ae3ebb'>
+      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='593' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='rc_avpair_parse' mangled-name='rc_avpair_parse' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='601' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_parse@@RADCLI_10' hash='ef52961ee11ac67f'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='601' column='1'/>
-      <parameter type-id='type-id-2' name='buffer' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='601' column='1'/>
-      <parameter type-id='type-id-52' name='first_pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='601' column='1'/>
+    <function-decl name='rc_avpair_parse' mangled-name='rc_avpair_parse' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='657' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_parse@@RADCLI_10' hash='ef52961ee11ac67f'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='657' column='1'/>
+      <parameter type-id='type-id-2' name='buffer' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='657' column='1'/>
+      <parameter type-id='type-id-52' name='first_pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='657' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_avpair_tostr' mangled-name='rc_avpair_tostr' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='831' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_tostr@@RADCLI_10' hash='91b85d32d5c9a49d'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='831' column='1'/>
-      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='831' column='1'/>
-      <parameter type-id='type-id-30' name='name' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='831' column='1'/>
-      <parameter type-id='type-id-11' name='ln' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='831' column='1'/>
-      <parameter type-id='type-id-30' name='value' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='831' column='1'/>
-      <parameter type-id='type-id-11' name='lv' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='831' column='1'/>
+    <function-decl name='rc_avpair_tostr' mangled-name='rc_avpair_tostr' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='886' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_tostr@@RADCLI_10' hash='91b85d32d5c9a49d'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='886' column='1'/>
+      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='886' column='1'/>
+      <parameter type-id='type-id-30' name='name' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='886' column='1'/>
+      <parameter type-id='type-id-11' name='ln' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='886' column='1'/>
+      <parameter type-id='type-id-30' name='value' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='886' column='1'/>
+      <parameter type-id='type-id-11' name='lv' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='886' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_avpair_log' mangled-name='rc_avpair_log' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_log@@RADCLI_10' hash='9059a9be3701b246'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='952' column='1'/>
-      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='952' column='1'/>
-      <parameter type-id='type-id-30' name='buf' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='952' column='1'/>
-      <parameter type-id='type-id-55' name='buf_len' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='952' column='1'/>
+    <function-decl name='rc_avpair_log' mangled-name='rc_avpair_log' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1007' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_log@@RADCLI_10' hash='9059a9be3701b246'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1007' column='1'/>
+      <parameter type-id='type-id-53' name='pair' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1007' column='1'/>
+      <parameter type-id='type-id-30' name='buf' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1007' column='1'/>
+      <parameter type-id='type-id-55' name='buf_len' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1007' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='rc_avpair_get_uint32' mangled-name='rc_avpair_get_uint32' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_uint32@@RADCLI_10' hash='3af697f6f27bbe92'>
-      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='982' column='1'/>
-      <parameter type-id='type-id-46' name='res' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='982' column='1'/>
+    <function-decl name='rc_avpair_get_uint32' mangled-name='rc_avpair_get_uint32' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_uint32@@RADCLI_10' hash='3af697f6f27bbe92'>
+      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1037' column='1'/>
+      <parameter type-id='type-id-46' name='res' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1037' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_avpair_get_in6' mangled-name='rc_avpair_get_in6' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_in6@@RADCLI_10' hash='b48e148031b30d19'>
-      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1003' column='1'/>
-      <parameter type-id='type-id-42' name='res' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1003' column='1'/>
-      <parameter type-id='type-id-48' name='prefix' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1003' column='1'/>
+    <function-decl name='rc_avpair_get_in6' mangled-name='rc_avpair_get_in6' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1058' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_in6@@RADCLI_10' hash='b48e148031b30d19'>
+      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1058' column='1'/>
+      <parameter type-id='type-id-42' name='res' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1058' column='1'/>
+      <parameter type-id='type-id-48' name='prefix' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1058' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_avpair_get_raw' mangled-name='rc_avpair_get_raw' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1035' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_raw@@RADCLI_10' hash='f28c95ee7b0e5443'>
-      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1035' column='1'/>
-      <parameter type-id='type-id-31' name='res' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1035' column='1'/>
-      <parameter type-id='type-id-48' name='res_size' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1035' column='1'/>
+    <function-decl name='rc_avpair_get_raw' mangled-name='rc_avpair_get_raw' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1090' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_raw@@RADCLI_10' hash='f28c95ee7b0e5443'>
+      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1090' column='1'/>
+      <parameter type-id='type-id-31' name='res' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1090' column='1'/>
+      <parameter type-id='type-id-48' name='res_size' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1090' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_avpair_get_attr' mangled-name='rc_avpair_get_attr' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1055' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_attr@@RADCLI_10' hash='81652d0d54e9c92a'>
-      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1055' column='1'/>
-      <parameter type-id='type-id-48' name='type' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1055' column='1'/>
-      <parameter type-id='type-id-48' name='id' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1055' column='1'/>
+    <function-decl name='rc_avpair_get_attr' mangled-name='rc_avpair_get_attr' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_avpair_get_attr@@RADCLI_10' hash='81652d0d54e9c92a'>
+      <parameter type-id='type-id-53' name='vp' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1110' column='1'/>
+      <parameter type-id='type-id-48' name='type' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1110' column='1'/>
+      <parameter type-id='type-id-48' name='id' filepath='/home/nmav/projects/radcli/lib/avpair.c' line='1110' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='inet_ntoa' filepath='/usr/include/arpa/inet.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inet_ntoa' hash='02a096d257a5e00d'>
@@ -416,6 +418,13 @@
       <parameter type-id='type-id-57'/>
       <parameter type-id='type-id-58'/>
       <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='__assert_fail' filepath='/usr/include/assert.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='__assert_fail' hash='f20e7a25b596c040'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='__ctype_b_loc' filepath='/usr/include/ctype.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='__ctype_b_loc' hash='2d54aef0745cb1f9'>
       <return type-id='type-id-41'/>
@@ -462,16 +471,6 @@
       <parameter type-id='type-id-3'/>
       <parameter type-id='type-id-23'/>
       <return type-id='type-id-3'/>
-    </function-decl>
-    <function-decl name='strcpy' filepath='/usr/include/string.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strcpy' hash='d2c49d83b30fb50c'>
-      <parameter type-id='type-id-30'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='strcat' filepath='/usr/include/string.h' line='149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strcat' hash='d2c49d83b30fb50c'>
-      <parameter type-id='type-id-30'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-30'/>
     </function-decl>
     <function-decl name='strchr' filepath='/usr/include/string.h' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strchr' hash='1b0d39e45ce45198'>
       <parameter type-id='type-id-2'/>
@@ -547,7 +546,7 @@
     <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='512' hash='f8859bc464d8cd16' id='type-id-75'>
       <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-23' size-in-bits='64' is-anonymous='yes' hash='6e87a8ff484907ad' id='type-id-61'/>
     </array-type-def>
-    <enum-decl name='rc_attr_type' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='115' column='1' hash='d5b96d74a4f35e62' id='type-id-76'>
+    <enum-decl name='rc_attr_type' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='116' column='1' hash='d5b96d74a4f35e62' id='type-id-76'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='PW_TYPE_STRING' value='0'/>
       <enumerator name='PW_TYPE_INTEGER' value='1'/>
@@ -557,7 +556,7 @@
       <enumerator name='PW_TYPE_IPV6PREFIX' value='5'/>
       <enumerator name='PW_TYPE_MAX' value='6'/>
     </enum-decl>
-    <enum-decl name='rc_standard_codes' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='127' column='1' hash='e41dfe5328868d85' id='type-id-78'>
+    <enum-decl name='rc_standard_codes' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='128' column='1' hash='e41dfe5328868d85' id='type-id-78'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='PW_ACCESS_REQUEST' value='1'/>
       <enumerator name='PW_ACCESS_ACCEPT' value='2'/>
@@ -573,191 +572,191 @@
       <enumerator name='PW_STATUS_SERVER' value='12'/>
       <enumerator name='PW_STATUS_CLIENT' value='13'/>
     </enum-decl>
-    <enum-decl name='rc_type' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='69' column='1' hash='27d67a40aa4b9efa' id='type-id-79'>
+    <enum-decl name='rc_type' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='70' column='1' hash='27d67a40aa4b9efa' id='type-id-79'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='AUTH' value='0'/>
       <enumerator name='ACCT' value='1'/>
     </enum-decl>
     <type-decl name='int' size-in-bits='32' hash='09d17c08f594edc7' id='type-id-11'/>
     <type-decl name='long int' size-in-bits='64' hash='b119fe0931d2ee10#2' id='type-id-12'/>
-    <class-decl name='dict_attr' is-struct='yes' visibility='default' size-in-bits='768' filepath='../include/radcli/radcli.h' line='433' column='1' hash='e01c5fd639f87215' id='type-id-13'>
+    <class-decl name='dict_attr' is-struct='yes' visibility='default' size-in-bits='768' filepath='../include/radcli/radcli.h' line='434' column='1' hash='e01c5fd639f87215' id='type-id-13'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='435' column='1'/>
+        <var-decl name='name' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='436' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='value' type-id='type-id-80' visibility='default' filepath='../include/radcli/radcli.h' line='436' column='1'/>
+        <var-decl name='value' type-id='type-id-80' visibility='default' filepath='../include/radcli/radcli.h' line='437' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='type' type-id='type-id-81' visibility='default' filepath='../include/radcli/radcli.h' line='437' column='1'/>
+        <var-decl name='type' type-id='type-id-81' visibility='default' filepath='../include/radcli/radcli.h' line='438' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='next' type-id='type-id-82' visibility='default' filepath='../include/radcli/radcli.h' line='438' column='1'/>
+        <var-decl name='next' type-id='type-id-82' visibility='default' filepath='../include/radcli/radcli.h' line='439' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='dict_value' is-struct='yes' visibility='default' size-in-bits='1152' filepath='../include/radcli/radcli.h' line='441' column='1' hash='74a2158e844e121a' id='type-id-15'>
+    <class-decl name='dict_value' is-struct='yes' visibility='default' size-in-bits='1152' filepath='../include/radcli/radcli.h' line='442' column='1' hash='74a2158e844e121a' id='type-id-15'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='attrname' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='443' column='1'/>
+        <var-decl name='attrname' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='444' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='520'>
-        <var-decl name='name' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='444' column='1'/>
+        <var-decl name='name' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='445' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='value' type-id='type-id-20' visibility='default' filepath='../include/radcli/radcli.h' line='445' column='1'/>
+        <var-decl name='value' type-id='type-id-20' visibility='default' filepath='../include/radcli/radcli.h' line='446' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='next' type-id='type-id-83' visibility='default' filepath='../include/radcli/radcli.h' line='446' column='1'/>
+        <var-decl name='next' type-id='type-id-83' visibility='default' filepath='../include/radcli/radcli.h' line='447' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='dict_vendor' is-struct='yes' visibility='default' size-in-bits='640' filepath='../include/radcli/radcli.h' line='449' column='1' hash='7d643bf1c351ebed' id='type-id-17'>
+    <class-decl name='dict_vendor' is-struct='yes' visibility='default' size-in-bits='640' filepath='../include/radcli/radcli.h' line='450' column='1' hash='7d643bf1c351ebed' id='type-id-17'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='vendorname' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='451' column='1'/>
+        <var-decl name='vendorname' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='452' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='vendorpec' type-id='type-id-20' visibility='default' filepath='../include/radcli/radcli.h' line='452' column='1'/>
+        <var-decl name='vendorpec' type-id='type-id-20' visibility='default' filepath='../include/radcli/radcli.h' line='453' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='next' type-id='type-id-84' visibility='default' filepath='../include/radcli/radcli.h' line='453' column='1'/>
+        <var-decl name='next' type-id='type-id-84' visibility='default' filepath='../include/radcli/radcli.h' line='454' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='rc_aaa_ctx_st' is-struct='yes' visibility='default' size-in-bits='2184' filepath='../include/includes.h' line='214' column='1' hash='68ea9703fcbff041' id='type-id-85'>
+    <class-decl name='rc_aaa_ctx_st' is-struct='yes' visibility='default' size-in-bits='2184' filepath='../include/includes.h' line='206' column='1' hash='68ea9703fcbff041' id='type-id-85'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='secret' type-id='type-id-68' visibility='default' filepath='../include/includes.h' line='216' column='1'/>
+        <var-decl name='secret' type-id='type-id-68' visibility='default' filepath='../include/includes.h' line='208' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2056'>
-        <var-decl name='request_vector' type-id='type-id-25' visibility='default' filepath='../include/includes.h' line='217' column='1'/>
+        <var-decl name='request_vector' type-id='type-id-25' visibility='default' filepath='../include/includes.h' line='209' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='rc_conf' is-struct='yes' visibility='default' size-in-bits='3136' filepath='../include/includes.h' line='192' column='1' hash='49880ab9f1e09a29' id='type-id-86'>
+    <class-decl name='rc_conf' is-struct='yes' visibility='default' size-in-bits='3136' filepath='../include/includes.h' line='184' column='1' hash='49880ab9f1e09a29' id='type-id-86'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='config_options' type-id='type-id-87' visibility='default' filepath='../include/includes.h' line='194' column='1'/>
+        <var-decl name='config_options' type-id='type-id-87' visibility='default' filepath='../include/includes.h' line='186' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nas_addr' type-id='type-id-88' visibility='default' filepath='../include/includes.h' line='195' column='1'/>
+        <var-decl name='nas_addr' type-id='type-id-88' visibility='default' filepath='../include/includes.h' line='187' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='nas_addr_set' type-id='type-id-47' visibility='default' filepath='../include/includes.h' line='196' column='1'/>
+        <var-decl name='nas_addr_set' type-id='type-id-47' visibility='default' filepath='../include/includes.h' line='188' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='own_bind_addr' type-id='type-id-88' visibility='default' filepath='../include/includes.h' line='198' column='1'/>
+        <var-decl name='own_bind_addr' type-id='type-id-88' visibility='default' filepath='../include/includes.h' line='190' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='own_bind_addr_set' type-id='type-id-47' visibility='default' filepath='../include/includes.h' line='199' column='1'/>
+        <var-decl name='own_bind_addr_set' type-id='type-id-47' visibility='default' filepath='../include/includes.h' line='191' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='first_dict_read' type-id='type-id-30' visibility='default' filepath='../include/includes.h' line='204' column='1'/>
+        <var-decl name='first_dict_read' type-id='type-id-30' visibility='default' filepath='../include/includes.h' line='196' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='dictionary_attributes' type-id='type-id-82' visibility='default' filepath='../include/includes.h' line='205' column='1'/>
+        <var-decl name='dictionary_attributes' type-id='type-id-82' visibility='default' filepath='../include/includes.h' line='197' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='dictionary_values' type-id='type-id-83' visibility='default' filepath='../include/includes.h' line='206' column='1'/>
+        <var-decl name='dictionary_values' type-id='type-id-83' visibility='default' filepath='../include/includes.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='dictionary_vendors' type-id='type-id-84' visibility='default' filepath='../include/includes.h' line='207' column='1'/>
+        <var-decl name='dictionary_vendors' type-id='type-id-84' visibility='default' filepath='../include/includes.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='so' type-id='type-id-89' visibility='default' filepath='../include/includes.h' line='209' column='1'/>
+        <var-decl name='so' type-id='type-id-89' visibility='default' filepath='../include/includes.h' line='201' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3072'>
-        <var-decl name='so_type' type-id='type-id-47' visibility='default' filepath='../include/includes.h' line='210' column='1'/>
+        <var-decl name='so_type' type-id='type-id-47' visibility='default' filepath='../include/includes.h' line='202' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='rc_sockets_override' is-struct='yes' visibility='default' size-in-bits='576' filepath='../include/includes.h' line='175' column='1' hash='ef4426f46565aa5d' id='type-id-90'>
+    <class-decl name='rc_sockets_override' is-struct='yes' visibility='default' size-in-bits='576' filepath='../include/includes.h' line='167' column='1' hash='ef4426f46565aa5d' id='type-id-90'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ptr' type-id='type-id-3' visibility='default' filepath='../include/includes.h' line='176' column='1'/>
+        <var-decl name='ptr' type-id='type-id-3' visibility='default' filepath='../include/includes.h' line='168' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='static_secret' type-id='type-id-2' visibility='default' filepath='../include/includes.h' line='177' column='1'/>
+        <var-decl name='static_secret' type-id='type-id-2' visibility='default' filepath='../include/includes.h' line='169' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='get_fd' type-id='type-id-91' visibility='default' filepath='../include/includes.h' line='178' column='1'/>
+        <var-decl name='get_fd' type-id='type-id-91' visibility='default' filepath='../include/includes.h' line='170' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='get_active_fd' type-id='type-id-92' visibility='default' filepath='../include/includes.h' line='182' column='1'/>
+        <var-decl name='get_active_fd' type-id='type-id-92' visibility='default' filepath='../include/includes.h' line='174' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='close_fd' type-id='type-id-93' visibility='default' filepath='../include/includes.h' line='183' column='1'/>
+        <var-decl name='close_fd' type-id='type-id-93' visibility='default' filepath='../include/includes.h' line='175' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='sendto' type-id='type-id-94' visibility='default' filepath='../include/includes.h' line='184' column='1'/>
+        <var-decl name='sendto' type-id='type-id-94' visibility='default' filepath='../include/includes.h' line='176' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='recvfrom' type-id='type-id-95' visibility='default' filepath='../include/includes.h' line='186' column='1'/>
+        <var-decl name='recvfrom' type-id='type-id-95' visibility='default' filepath='../include/includes.h' line='178' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='lock' type-id='type-id-92' visibility='default' filepath='../include/includes.h' line='188' column='1'/>
+        <var-decl name='lock' type-id='type-id-92' visibility='default' filepath='../include/includes.h' line='180' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='unlock' type-id='type-id-92' visibility='default' filepath='../include/includes.h' line='189' column='1'/>
+        <var-decl name='unlock' type-id='type-id-92' visibility='default' filepath='../include/includes.h' line='181' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='rc_value_pair' is-struct='yes' visibility='default' size-in-bits='3072' filepath='../include/radcli/radcli.h' line='478' column='1' hash='20c4c7a71c281e48' id='type-id-96'>
+    <class-decl name='rc_value_pair' is-struct='yes' visibility='default' size-in-bits='3072' filepath='../include/radcli/radcli.h' line='483' column='1' hash='20c4c7a71c281e48' id='type-id-96'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='480' column='1'/>
+        <var-decl name='name' type-id='type-id-72' visibility='default' filepath='../include/radcli/radcli.h' line='485' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='attribute' type-id='type-id-80' visibility='default' filepath='../include/radcli/radcli.h' line='481' column='1'/>
+        <var-decl name='attribute' type-id='type-id-80' visibility='default' filepath='../include/radcli/radcli.h' line='486' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='type' type-id='type-id-81' visibility='default' filepath='../include/radcli/radcli.h' line='482' column='1'/>
+        <var-decl name='type' type-id='type-id-81' visibility='default' filepath='../include/radcli/radcli.h' line='487' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='lvalue' type-id='type-id-20' visibility='default' filepath='../include/radcli/radcli.h' line='483' column='1'/>
+        <var-decl name='lvalue' type-id='type-id-20' visibility='default' filepath='../include/radcli/radcli.h' line='488' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='strvalue' type-id='type-id-66' visibility='default' filepath='../include/radcli/radcli.h' line='484' column='1'/>
+        <var-decl name='strvalue' type-id='type-id-66' visibility='default' filepath='../include/radcli/radcli.h' line='489' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='next' type-id='type-id-97' visibility='default' filepath='../include/radcli/radcli.h' line='485' column='1'/>
+        <var-decl name='next' type-id='type-id-97' visibility='default' filepath='../include/radcli/radcli.h' line='490' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2816'>
-        <var-decl name='pad' type-id='type-id-70' visibility='default' filepath='../include/radcli/radcli.h' line='486' column='1'/>
+        <var-decl name='pad' type-id='type-id-70' visibility='default' filepath='../include/radcli/radcli.h' line='491' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='send_data' is-struct='yes' visibility='default' size-in-bits='448' filepath='../include/radcli/radcli.h' line='489' column='1' hash='ed01b9ce36055e2c' id='type-id-98'>
+    <class-decl name='send_data' is-struct='yes' visibility='default' size-in-bits='448' filepath='../include/radcli/radcli.h' line='499' column='1' hash='ed01b9ce36055e2c' id='type-id-98'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='code' type-id='type-id-99' visibility='default' filepath='../include/radcli/radcli.h' line='491' column='1'/>
+        <var-decl name='code' type-id='type-id-99' visibility='default' filepath='../include/radcli/radcli.h' line='501' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='seq_nbr' type-id='type-id-99' visibility='default' filepath='../include/radcli/radcli.h' line='492' column='1'/>
+        <var-decl name='seq_nbr' type-id='type-id-99' visibility='default' filepath='../include/radcli/radcli.h' line='502' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='server' type-id='type-id-30' visibility='default' filepath='../include/radcli/radcli.h' line='493' column='1'/>
+        <var-decl name='server' type-id='type-id-30' visibility='default' filepath='../include/radcli/radcli.h' line='503' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='svc_port' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='494' column='1'/>
+        <var-decl name='svc_port' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='504' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='secret' type-id='type-id-30' visibility='default' filepath='../include/radcli/radcli.h' line='495' column='1'/>
+        <var-decl name='secret' type-id='type-id-30' visibility='default' filepath='../include/radcli/radcli.h' line='505' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='timeout' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='496' column='1'/>
+        <var-decl name='timeout' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='506' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='retries' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='497' column='1'/>
+        <var-decl name='retries' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='507' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='send_pairs' type-id='type-id-53' visibility='default' filepath='../include/radcli/radcli.h' line='498' column='1'/>
+        <var-decl name='send_pairs' type-id='type-id-53' visibility='default' filepath='../include/radcli/radcli.h' line='508' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='receive_pairs' type-id='type-id-53' visibility='default' filepath='../include/radcli/radcli.h' line='499' column='1'/>
+        <var-decl name='receive_pairs' type-id='type-id-53' visibility='default' filepath='../include/radcli/radcli.h' line='509' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='server' is-struct='yes' visibility='default' size-in-bits='1728' filepath='../include/radcli/radcli.h' line='90' column='1' hash='a17cce6752d91333' id='type-id-100'>
+    <class-decl name='server' is-struct='yes' visibility='default' size-in-bits='1728' filepath='../include/radcli/radcli.h' line='91' column='1' hash='a17cce6752d91333' id='type-id-100'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='max' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='91' column='1'/>
+        <var-decl name='max' type-id='type-id-11' visibility='default' filepath='../include/radcli/radcli.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='name' type-id='type-id-60' visibility='default' filepath='../include/radcli/radcli.h' line='92' column='1'/>
+        <var-decl name='name' type-id='type-id-60' visibility='default' filepath='../include/radcli/radcli.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='port' type-id='type-id-26' visibility='default' filepath='../include/radcli/radcli.h' line='93' column='1'/>
+        <var-decl name='port' type-id='type-id-26' visibility='default' filepath='../include/radcli/radcli.h' line='94' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='secret' type-id='type-id-60' visibility='default' filepath='../include/radcli/radcli.h' line='94' column='1'/>
+        <var-decl name='secret' type-id='type-id-60' visibility='default' filepath='../include/radcli/radcli.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='deadtime_ends' type-id='type-id-75' visibility='default' filepath='../include/radcli/radcli.h' line='95' column='1'/>
+        <var-decl name='deadtime_ends' type-id='type-id-75' visibility='default' filepath='../include/radcli/radcli.h' line='96' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='sockaddr' is-struct='yes' visibility='default' size-in-bits='128' filepath='/usr/include/bits/socket.h' line='184' column='1' hash='17b889f8dd08e00f' id='type-id-101'>
@@ -779,21 +778,21 @@
         <var-decl name='__ss_align' type-id='type-id-23' visibility='default' filepath='/usr/include/bits/socket.h' line='201' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='RC_AAA_CTX' type-id='type-id-85' size-in-bits='2184' filepath='../include/radcli/radcli.h' line='505' column='1' id='type-id-103'/>
-    <typedef-decl name='SEND_DATA' type-id='type-id-98' size-in-bits='448' filepath='../include/radcli/radcli.h' line='500' column='1' id='type-id-104'/>
-    <typedef-decl name='SERVER' type-id='type-id-100' size-in-bits='1728' filepath='../include/radcli/radcli.h' line='96' column='1' id='type-id-105'/>
-    <typedef-decl name='VALUE_PAIR' type-id='type-id-96' size-in-bits='3072' filepath='../include/radcli/radcli.h' line='487' column='1' id='type-id-106'/>
+    <typedef-decl name='RC_AAA_CTX' type-id='type-id-85' size-in-bits='2184' filepath='../include/radcli/radcli.h' line='524' column='1' id='type-id-103'/>
+    <typedef-decl name='SEND_DATA' type-id='type-id-98' size-in-bits='448' filepath='../include/radcli/radcli.h' line='510' column='1' id='type-id-104'/>
+    <typedef-decl name='SERVER' type-id='type-id-100' size-in-bits='1728' filepath='../include/radcli/radcli.h' line='97' column='1' id='type-id-105'/>
+    <typedef-decl name='VALUE_PAIR' type-id='type-id-96' size-in-bits='3072' filepath='../include/radcli/radcli.h' line='492' column='1' id='type-id-106'/>
     <typedef-decl name='__socklen_t' type-id='type-id-47' size-in-bits='32' filepath='/usr/include/bits/types.h' line='210' column='1' hash='e66b43f97c38e87a' id='type-id-107'/>
     <typedef-decl name='__ssize_t' type-id='type-id-12' size-in-bits='64' filepath='/usr/include/bits/types.h' line='194' column='1' hash='b119fe0931d2ee10' id='type-id-108'/>
     <typedef-decl name='__uint16_t' type-id='type-id-38' size-in-bits='16' filepath='/usr/include/bits/types.h' line='40' column='1' hash='d7723bb93a30b11d' id='type-id-109'/>
     <typedef-decl name='__uint32_t' type-id='type-id-47' size-in-bits='32' filepath='/usr/include/bits/types.h' line='42' column='1' hash='e66b43f97c38e87a' id='type-id-110'/>
     <typedef-decl name='__uint64_t' type-id='type-id-23' size-in-bits='64' filepath='/usr/include/bits/types.h' line='45' column='1' hash='8fdc5eea2983a729' id='type-id-111'/>
     <typedef-decl name='__uint8_t' type-id='type-id-112' size-in-bits='8' filepath='/usr/include/bits/types.h' line='38' column='1' hash='6ebac62b3366db68' id='type-id-113'/>
-    <typedef-decl name='rc_attr_type' type-id='type-id-76' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='123' column='1' hash='d5b96d74a4f35e62' id='type-id-81'/>
-    <typedef-decl name='rc_handle' type-id='type-id-86' size-in-bits='3136' filepath='../include/radcli/radcli.h' line='84' column='1' id='type-id-114'/>
-    <typedef-decl name='rc_sockets_override' type-id='type-id-90' size-in-bits='576' filepath='../include/includes.h' line='190' column='1' id='type-id-89'/>
-    <typedef-decl name='rc_standard_codes' type-id='type-id-78' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='141' column='1' hash='e41dfe5328868d85' id='type-id-115'/>
-    <typedef-decl name='rc_type' type-id='type-id-79' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='72' column='1' hash='27d67a40aa4b9efa' id='type-id-116'/>
+    <typedef-decl name='rc_attr_type' type-id='type-id-76' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='124' column='1' hash='d5b96d74a4f35e62' id='type-id-81'/>
+    <typedef-decl name='rc_handle' type-id='type-id-86' size-in-bits='3136' filepath='../include/radcli/radcli.h' line='85' column='1' id='type-id-114'/>
+    <typedef-decl name='rc_sockets_override' type-id='type-id-90' size-in-bits='576' filepath='../include/includes.h' line='182' column='1' id='type-id-89'/>
+    <typedef-decl name='rc_standard_codes' type-id='type-id-78' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='142' column='1' hash='e41dfe5328868d85' id='type-id-115'/>
+    <typedef-decl name='rc_type' type-id='type-id-79' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='73' column='1' hash='27d67a40aa4b9efa' id='type-id-116'/>
     <typedef-decl name='sa_family_t' type-id='type-id-38' size-in-bits='16' filepath='/usr/include/bits/sockaddr.h' line='28' column='1' hash='d7723bb93a30b11d' id='type-id-102'/>
     <typedef-decl name='size_t' type-id='type-id-23' size-in-bits='64' filepath='/usr/lib/gcc/x86_64-redhat-linux/15/include/stddef.h' line='229' column='1' hash='8fdc5eea2983a729' id='type-id-55'/>
     <typedef-decl name='socklen_t' type-id='type-id-107' size-in-bits='32' filepath='/usr/include/bits/socket.h' line='33' column='1' hash='e66b43f97c38e87a' id='type-id-58'/>
@@ -853,83 +852,89 @@
         <var-decl name='val' type-id='type-id-3' visibility='default' filepath='./options.h' line='26' column='1'/>
       </data-member>
     </class-decl>
-    <function-decl name='rc_buildreq' mangled-name='rc_buildreq' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_buildreq@@RADCLI_10' hash='7cfd40833daf367f'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='41' column='1'/>
-      <parameter type-id='type-id-121' name='data' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='41' column='1'/>
-      <parameter type-id='type-id-11' name='code' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='41' column='1'/>
-      <parameter type-id='type-id-30' name='server' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='41' column='1'/>
-      <parameter type-id='type-id-38' name='port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='42' column='1'/>
-      <parameter type-id='type-id-30' name='secret' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='42' column='1'/>
-      <parameter type-id='type-id-11' name='timeout' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='42' column='1'/>
-      <parameter type-id='type-id-11' name='retries' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='42' column='1'/>
+    <function-decl name='rc_buildreq' mangled-name='rc_buildreq' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='45' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_buildreq@@RADCLI_10' hash='7cfd40833daf367f'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='45' column='1'/>
+      <parameter type-id='type-id-121' name='data' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='45' column='1'/>
+      <parameter type-id='type-id-11' name='code' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='45' column='1'/>
+      <parameter type-id='type-id-30' name='server' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='45' column='1'/>
+      <parameter type-id='type-id-38' name='port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='46' column='1'/>
+      <parameter type-id='type-id-30' name='secret' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='46' column='1'/>
+      <parameter type-id='type-id-11' name='timeout' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='46' column='1'/>
+      <parameter type-id='type-id-11' name='retries' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='46' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='rc_aaa_ctx' mangled-name='rc_aaa_ctx' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_aaa_ctx@@RADCLI_10' hash='1340f48c31fa6120'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='70' column='1'/>
-      <parameter type-id='type-id-120' name='ctx' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='70' column='1'/>
-      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='70' column='1'/>
-      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='71' column='1'/>
-      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='71' column='1'/>
-      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='71' column='1'/>
-      <parameter type-id='type-id-11' name='add_nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='72' column='1'/>
-      <parameter type-id='type-id-115' name='request_type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='72' column='1'/>
+    <function-decl name='rc_aaa_ctx' mangled-name='rc_aaa_ctx' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_aaa_ctx@@RADCLI_10' hash='1340f48c31fa6120'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='164' column='1'/>
+      <parameter type-id='type-id-120' name='ctx' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='164' column='1'/>
+      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='164' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='165' column='1'/>
+      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='165' column='1'/>
+      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='165' column='1'/>
+      <parameter type-id='type-id-11' name='add_nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='166' column='1'/>
+      <parameter type-id='type-id-115' name='request_type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='166' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_aaa_ctx_server' mangled-name='rc_aaa_ctx_server' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_aaa_ctx_server@@RADCLI_10' hash='263fed8cea076c4f'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='111' column='1'/>
-      <parameter type-id='type-id-120' name='ctx' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='111' column='1'/>
-      <parameter type-id='type-id-122' name='aaaserver' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='111' column='1'/>
-      <parameter type-id='type-id-116' name='type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='112' column='1'/>
-      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='113' column='1'/>
-      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='114' column='1'/>
-      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='114' column='1'/>
-      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='115' column='1'/>
-      <parameter type-id='type-id-11' name='add_nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='115' column='1'/>
-      <parameter type-id='type-id-115' name='request_type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='116' column='1'/>
+    <function-decl name='rc_aaa_ctx_server' mangled-name='rc_aaa_ctx_server' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='203' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_aaa_ctx_server@@RADCLI_10' hash='263fed8cea076c4f'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='203' column='1'/>
+      <parameter type-id='type-id-120' name='ctx' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='203' column='1'/>
+      <parameter type-id='type-id-122' name='aaaserver' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='203' column='1'/>
+      <parameter type-id='type-id-116' name='type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='204' column='1'/>
+      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='205' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='206' column='1'/>
+      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='206' column='1'/>
+      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='207' column='1'/>
+      <parameter type-id='type-id-11' name='add_nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='207' column='1'/>
+      <parameter type-id='type-id-115' name='request_type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='208' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_aaa' mangled-name='rc_aaa' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_aaa@@RADCLI_10' hash='0bd54b12dc7fab85'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='215' column='1'/>
-      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='215' column='1'/>
-      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='215' column='1'/>
-      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='216' column='1'/>
-      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='216' column='1'/>
-      <parameter type-id='type-id-11' name='add_nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='216' column='1'/>
-      <parameter type-id='type-id-115' name='request_type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='217' column='1'/>
+    <function-decl name='rc_aaa' mangled-name='rc_aaa' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='281' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_aaa@@RADCLI_10' hash='0bd54b12dc7fab85'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='281' column='1'/>
+      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='281' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='281' column='1'/>
+      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='282' column='1'/>
+      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='282' column='1'/>
+      <parameter type-id='type-id-11' name='add_nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='282' column='1'/>
+      <parameter type-id='type-id-115' name='request_type' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='283' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_auth' mangled-name='rc_auth' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='235' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_auth@@RADCLI_10' hash='b653c9a88b550ab8'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='235' column='1'/>
-      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='235' column='1'/>
-      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='235' column='1'/>
-      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='236' column='1'/>
-      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='236' column='1'/>
+    <function-decl name='rc_auth' mangled-name='rc_auth' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_auth@@RADCLI_10' hash='b653c9a88b550ab8'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='301' column='1'/>
+      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='301' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='301' column='1'/>
+      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='302' column='1'/>
+      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='302' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_auth_proxy' mangled-name='rc_auth_proxy' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='257' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_auth_proxy@@RADCLI_10' hash='fa41cd0d1cfcedb5'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='257' column='1'/>
-      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='257' column='1'/>
-      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='257' column='1'/>
-      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='258' column='1'/>
+    <function-decl name='rc_auth_proxy' mangled-name='rc_auth_proxy' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='323' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_auth_proxy@@RADCLI_10' hash='fa41cd0d1cfcedb5'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='323' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='323' column='1'/>
+      <parameter type-id='type-id-52' name='received' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='323' column='1'/>
+      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='324' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_acct' mangled-name='rc_acct' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_acct@@RADCLI_10' hash='43c292fd0273b7a9'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='274' column='1'/>
-      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='274' column='1'/>
-      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='274' column='1'/>
+    <function-decl name='rc_acct' mangled-name='rc_acct' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_acct@@RADCLI_10' hash='43c292fd0273b7a9'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='438' column='1'/>
+      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='438' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='438' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_acct_proxy' mangled-name='rc_acct_proxy' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_acct_proxy@@RADCLI_10' hash='512e428547b00817'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='287' column='1'/>
-      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='287' column='1'/>
+    <function-decl name='rc_acct_proxy' mangled-name='rc_acct_proxy' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='353' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_acct_proxy@@RADCLI_10' hash='512e428547b00817'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='353' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='353' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_check' mangled-name='rc_check' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_check@@RADCLI_10' hash='b1df0502a05212bb'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='303' column='1'/>
-      <parameter type-id='type-id-30' name='host' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='303' column='1'/>
-      <parameter type-id='type-id-30' name='secret' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='303' column='1'/>
-      <parameter type-id='type-id-38' name='port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='303' column='1'/>
-      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='304' column='1'/>
+    <function-decl name='rc_acct_async' mangled-name='rc_acct_async' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='438' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_acct_async@@RADCLI_10' hash='43c292fd0273b7a9'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='438' column='1'/>
+      <parameter type-id='type-id-20' name='nas_port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='438' column='1'/>
+      <parameter type-id='type-id-53' name='send' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='438' column='1'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='rc_check' mangled-name='rc_check' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_check@@RADCLI_10' hash='b1df0502a05212bb'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='459' column='1'/>
+      <parameter type-id='type-id-30' name='host' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='459' column='1'/>
+      <parameter type-id='type-id-30' name='secret' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='459' column='1'/>
+      <parameter type-id='type-id-38' name='port' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='459' column='1'/>
+      <parameter type-id='type-id-30' name='msg' filepath='/home/nmav/projects/radcli/lib/buildreq.c' line='460' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='random' filepath='/usr/include/stdlib.h' line='521' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='random' hash='52c0efb08d2aa513'>
@@ -982,7 +987,7 @@
     <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='64' hash='e1c8b625c73024c4' id='type-id-141'>
       <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-23' size-in-bits='64' is-anonymous='yes' hash='6e87a8ff484907ad' id='type-id-61'/>
     </array-type-def>
-    <enum-decl name='rc_socket_type' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='100' column='1' hash='3abaa96b612ae129' id='type-id-142'>
+    <enum-decl name='rc_socket_type' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='101' column='1' hash='3abaa96b612ae129' id='type-id-142'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='RC_SOCKET_UDP' value='0'/>
       <enumerator name='RC_SOCKET_TLS' value='1'/>
@@ -1107,7 +1112,7 @@
     <typedef-decl name='__off64_t' type-id='type-id-12' size-in-bits='64' filepath='/usr/include/bits/types.h' line='153' column='1' hash='b119fe0931d2ee10' id='type-id-149'/>
     <typedef-decl name='__off_t' type-id='type-id-12' size-in-bits='64' filepath='/usr/include/bits/types.h' line='152' column='1' hash='b119fe0931d2ee10' id='type-id-147'/>
     <typedef-decl name='__pid_t' type-id='type-id-11' size-in-bits='32' filepath='/usr/include/bits/types.h' line='154' column='1' hash='09d17c08f594edc7' id='type-id-156'/>
-    <typedef-decl name='rc_socket_type' type-id='type-id-142' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='105' column='1' hash='3abaa96b612ae129' id='type-id-157'/>
+    <typedef-decl name='rc_socket_type' type-id='type-id-142' size-in-bits='32' alignment-in-bits='32' filepath='../include/radcli/radcli.h' line='106' column='1' hash='3abaa96b612ae129' id='type-id-157'/>
     <pointer-type-def type-id='type-id-154' size-in-bits='64' hash='4cdc26b379a5c62d' id='type-id-158'/>
     <qualified-type-def type-id='type-id-158' restrict='yes' hash='6a2cf982d0fba87f' id='type-id-159'/>
     <pointer-type-def type-id='type-id-144' size-in-bits='64' hash='071f36dcbe00ad00' id='type-id-146'/>
@@ -1126,67 +1131,67 @@
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-164'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-165'/>
     <qualified-type-def type-id='type-id-3' restrict='yes' id='type-id-166'/>
-    <function-decl name='rc_add_config' mangled-name='rc_add_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='294' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_add_config@@RADCLI_10' hash='9555b6198352d410'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='294' column='1'/>
-      <parameter type-id='type-id-2' name='option_name' filepath='/home/nmav/projects/radcli/lib/config.c' line='294' column='1'/>
-      <parameter type-id='type-id-2' name='option_val' filepath='/home/nmav/projects/radcli/lib/config.c' line='294' column='1'/>
-      <parameter type-id='type-id-2' name='source' filepath='/home/nmav/projects/radcli/lib/config.c' line='294' column='1'/>
-      <parameter type-id='type-id-11' name='line' filepath='/home/nmav/projects/radcli/lib/config.c' line='294' column='1'/>
+    <function-decl name='rc_add_config' mangled-name='rc_add_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='295' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_add_config@@RADCLI_10' hash='9555b6198352d410'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='295' column='1'/>
+      <parameter type-id='type-id-2' name='option_name' filepath='/home/nmav/projects/radcli/lib/config.c' line='295' column='1'/>
+      <parameter type-id='type-id-2' name='option_val' filepath='/home/nmav/projects/radcli/lib/config.c' line='295' column='1'/>
+      <parameter type-id='type-id-2' name='source' filepath='/home/nmav/projects/radcli/lib/config.c' line='295' column='1'/>
+      <parameter type-id='type-id-11' name='line' filepath='/home/nmav/projects/radcli/lib/config.c' line='295' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_config_init' mangled-name='rc_config_init' filepath='/home/nmav/projects/radcli/lib/config.c' line='349' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_config_init@@RADCLI_10' hash='301447e85753c583'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='349' column='1'/>
+    <function-decl name='rc_config_init' mangled-name='rc_config_init' filepath='/home/nmav/projects/radcli/lib/config.c' line='362' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_config_init@@RADCLI_10' hash='301447e85753c583'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='362' column='1'/>
       <return type-id='type-id-130'/>
     </function-decl>
-    <function-decl name='rc_apply_config' mangled-name='rc_apply_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='500' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_apply_config@@RADCLI_10' hash='b6704dc70a55ac3c'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='500' column='1'/>
+    <function-decl name='rc_apply_config' mangled-name='rc_apply_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='519' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_apply_config@@RADCLI_10' hash='b6704dc70a55ac3c'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='519' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_read_config' mangled-name='rc_read_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='568' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_read_config@@RADCLI_10' hash='f1bd4031c3a977ce'>
-      <parameter type-id='type-id-2' name='filename' filepath='/home/nmav/projects/radcli/lib/config.c' line='568' column='1'/>
+    <function-decl name='rc_read_config' mangled-name='rc_read_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='618' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_read_config@@RADCLI_10' hash='f1bd4031c3a977ce'>
+      <parameter type-id='type-id-2' name='filename' filepath='/home/nmav/projects/radcli/lib/config.c' line='618' column='1'/>
       <return type-id='type-id-130'/>
     </function-decl>
-    <function-decl name='rc_conf_str' mangled-name='rc_conf_str' filepath='/home/nmav/projects/radcli/lib/config.c' line='708' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_conf_str@@RADCLI_10' hash='57390266c6026cfb'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='708' column='1'/>
-      <parameter type-id='type-id-2' name='optname' filepath='/home/nmav/projects/radcli/lib/config.c' line='708' column='1'/>
+    <function-decl name='rc_conf_str' mangled-name='rc_conf_str' filepath='/home/nmav/projects/radcli/lib/config.c' line='765' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_conf_str@@RADCLI_10' hash='57390266c6026cfb'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='765' column='1'/>
+      <parameter type-id='type-id-2' name='optname' filepath='/home/nmav/projects/radcli/lib/config.c' line='765' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='rc_conf_int' mangled-name='rc_conf_int' filepath='/home/nmav/projects/radcli/lib/config.c' line='747' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_conf_int@@RADCLI_10' hash='1b4b3bdd6142682c'>
+    <function-decl name='rc_conf_int' mangled-name='rc_conf_int' filepath='/home/nmav/projects/radcli/lib/config.c' line='804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_conf_int@@RADCLI_10' hash='1b4b3bdd6142682c'>
       <parameter type-id='type-id-51'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_conf_srv' mangled-name='rc_conf_srv' filepath='/home/nmav/projects/radcli/lib/config.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_conf_srv@@RADCLI_10' hash='222e9258b4d6fde1'>
+    <function-decl name='rc_conf_srv' mangled-name='rc_conf_srv' filepath='/home/nmav/projects/radcli/lib/config.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_conf_srv@@RADCLI_10' hash='222e9258b4d6fde1'>
       <parameter type-id='type-id-51'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-122'/>
     </function-decl>
-    <function-decl name='rc_test_config' mangled-name='rc_test_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='778' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_test_config@@RADCLI_10' hash='b8839c8a7cbb371f'>
+    <function-decl name='rc_test_config' mangled-name='rc_test_config' filepath='/home/nmav/projects/radcli/lib/config.c' line='835' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_test_config@@RADCLI_10' hash='b8839c8a7cbb371f'>
       <parameter type-id='type-id-130'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_find_server_addr' mangled-name='rc_find_server_addr' filepath='/home/nmav/projects/radcli/lib/config.c' line='912' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_find_server_addr@@RADCLI_10' hash='45aa6cd92a689c8d'>
-      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='912' column='1'/>
-      <parameter type-id='type-id-2' name='server_name' filepath='/home/nmav/projects/radcli/lib/config.c' line='912' column='1'/>
-      <parameter type-id='type-id-167' name='info' filepath='/home/nmav/projects/radcli/lib/config.c' line='913' column='1'/>
-      <parameter type-id='type-id-30' name='secret' filepath='/home/nmav/projects/radcli/lib/config.c' line='913' column='1'/>
-      <parameter type-id='type-id-116' name='type' filepath='/home/nmav/projects/radcli/lib/config.c' line='913' column='1'/>
+    <function-decl name='rc_find_server_addr' mangled-name='rc_find_server_addr' filepath='/home/nmav/projects/radcli/lib/config.c' line='964' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_find_server_addr@@RADCLI_10' hash='45aa6cd92a689c8d'>
+      <parameter type-id='type-id-51' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='964' column='1'/>
+      <parameter type-id='type-id-2' name='server_name' filepath='/home/nmav/projects/radcli/lib/config.c' line='964' column='1'/>
+      <parameter type-id='type-id-167' name='info' filepath='/home/nmav/projects/radcli/lib/config.c' line='965' column='1'/>
+      <parameter type-id='type-id-30' name='secret' filepath='/home/nmav/projects/radcli/lib/config.c' line='965' column='1'/>
+      <parameter type-id='type-id-116' name='type' filepath='/home/nmav/projects/radcli/lib/config.c' line='965' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_config_free' mangled-name='rc_config_free' filepath='/home/nmav/projects/radcli/lib/config.c' line='1062' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_config_free@@RADCLI_10' hash='353ae88bca3393cc'>
+    <function-decl name='rc_config_free' mangled-name='rc_config_free' filepath='/home/nmav/projects/radcli/lib/config.c' line='1114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_config_free@@RADCLI_10' hash='353ae88bca3393cc'>
       <parameter type-id='type-id-130'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='rc_new' mangled-name='rc_new' filepath='/home/nmav/projects/radcli/lib/config.c' line='1096' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_new@@RADCLI_10' hash='353ae88bca3393cc'>
+    <function-decl name='rc_new' mangled-name='rc_new' filepath='/home/nmav/projects/radcli/lib/config.c' line='1148' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_new@@RADCLI_10' hash='353ae88bca3393cc'>
       <return type-id='type-id-130'/>
     </function-decl>
-    <function-decl name='rc_destroy' mangled-name='rc_destroy' filepath='/home/nmav/projects/radcli/lib/config.c' line='1127' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_destroy@@RADCLI_10' hash='353ae88bca3393cc'>
+    <function-decl name='rc_destroy' mangled-name='rc_destroy' filepath='/home/nmav/projects/radcli/lib/config.c' line='1179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_destroy@@RADCLI_10' hash='353ae88bca3393cc'>
       <parameter type-id='type-id-130'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='rc_get_socket_type' mangled-name='rc_get_socket_type' filepath='/home/nmav/projects/radcli/lib/config.c' line='1151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_get_socket_type@@RADCLI_10' hash='6854e817773e3e1d'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='1151' column='1'/>
+    <function-decl name='rc_get_socket_type' mangled-name='rc_get_socket_type' filepath='/home/nmav/projects/radcli/lib/config.c' line='1203' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_get_socket_type@@RADCLI_10' hash='6854e817773e3e1d'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='1203' column='1'/>
       <return type-id='type-id-157'/>
     </function-decl>
     <function-decl name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='__errno_location' hash='c0e4f5f42afc96e0'>
@@ -1333,9 +1338,9 @@
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='rc_read_dictionary_from_buffer' mangled-name='rc_read_dictionary_from_buffer' filepath='/home/nmav/projects/radcli/lib/dict.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_read_dictionary_from_buffer@@RADCLI_10' hash='3d29dfbe20b2165a'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/dict.c' line='507' column='1'/>
-      <parameter type-id='type-id-2' name='buf' filepath='/home/nmav/projects/radcli/lib/dict.c' line='507' column='1'/>
-      <parameter type-id='type-id-55' name='size' filepath='/home/nmav/projects/radcli/lib/dict.c' line='507' column='1'/>
+      <parameter type-id='type-id-130'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-55'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='rc_dict_getattr' mangled-name='rc_dict_getattr' filepath='/home/nmav/projects/radcli/lib/dict.c' line='532' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_dict_getattr@@RADCLI_10' hash='9e8ae7c8fe5cb1c6'>
@@ -1456,12 +1461,12 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='log.c' comp-dir-path='/home/nmav/projects/radcli/lib' language='LANG_C11'>
-    <function-decl name='rc_setdebug' mangled-name='rc_setdebug' filepath='/home/nmav/projects/radcli/lib/log.c' line='16' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_setdebug@@RADCLI_10' hash='388da3fa973fde78'>
+    <function-decl name='rc_setdebug' mangled-name='rc_setdebug' filepath='/home/nmav/projects/radcli/lib/log.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_setdebug@@RADCLI_10' hash='388da3fa973fde78'>
       <parameter type-id='type-id-11'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='rc_openlog' mangled-name='rc_openlog' filepath='/home/nmav/projects/radcli/lib/log.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_openlog@@RADCLI_10' hash='53885bde0aa65efe'>
-      <parameter type-id='type-id-2' name='ident' filepath='/home/nmav/projects/radcli/lib/log.c' line='36' column='1'/>
+    <function-decl name='rc_openlog' mangled-name='rc_openlog' filepath='/home/nmav/projects/radcli/lib/log.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_openlog@@RADCLI_10' hash='53885bde0aa65efe'>
+      <parameter type-id='type-id-2' name='ident' filepath='/home/nmav/projects/radcli/lib/log.c' line='54' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='openlog' filepath='/usr/include/sys/syslog.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='openlog' hash='9e3d92cc5a49119c'>
@@ -1595,7 +1600,7 @@
     <pointer-type-def type-id='type-id-99' size-in-bits='64' hash='24d8cca8965ce13e' id='type-id-182'/>
     <pointer-type-def type-id='type-id-112' size-in-bits='64' hash='f0221758ecf0c0cb' id='type-id-186'/>
     <qualified-type-def type-id='type-id-3' restrict='yes' id='type-id-196'/>
-    <function-decl name='rc_send_server' mangled-name='rc_send_server' filepath='/home/nmav/projects/radcli/lib/sendserver.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_send_server@@RADCLI_10' hash='659156f6be7b3111'>
+    <function-decl name='rc_send_server' mangled-name='rc_send_server' filepath='/home/nmav/projects/radcli/lib/sendserver.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_send_server@@RADCLI_10' hash='659156f6be7b3111'>
       <parameter type-id='type-id-130'/>
       <parameter type-id='type-id-121'/>
       <parameter type-id='type-id-30'/>
@@ -1604,6 +1609,12 @@
     </function-decl>
     <function-decl name='gnutls_rnd' filepath='/usr/include/gnutls/crypto.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_rnd' hash='4ed095a3e8727273'>
       <parameter type-id='type-id-190'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-55'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='gnutls_memcmp' filepath='/usr/include/gnutls/gnutls.h' line='2321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_memcmp' hash='b6a97d07f8261bc0'>
+      <parameter type-id='type-id-3'/>
       <parameter type-id='type-id-3'/>
       <parameter type-id='type-id-55'/>
       <return type-id='type-id-11'/>
@@ -1684,7 +1695,12 @@
       <enumerator name='GNUTLS_CRT_RAWPK' value='3'/>
       <enumerator name='GNUTLS_CRT_MAX' value='3'/>
     </enum-decl>
-    <enum-decl name='gnutls_credentials_type_t' naming-typedef-id='type-id-204' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='287' column='1' hash='7be2a490e9a7a839' id='type-id-205'>
+    <enum-decl name='gnutls_close_request_t' naming-typedef-id='type-id-204' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='791' column='1' hash='66c82e28899d26fa' id='type-id-205'>
+      <underlying-type type-id='type-id-77'/>
+      <enumerator name='GNUTLS_SHUT_RDWR' value='0'/>
+      <enumerator name='GNUTLS_SHUT_WR' value='1'/>
+    </enum-decl>
+    <enum-decl name='gnutls_credentials_type_t' naming-typedef-id='type-id-206' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='287' column='1' hash='7be2a490e9a7a839' id='type-id-207'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='GNUTLS_CRD_CERTIFICATE' value='1'/>
       <enumerator name='GNUTLS_CRD_ANON' value='2'/>
@@ -1692,30 +1708,30 @@
       <enumerator name='GNUTLS_CRD_PSK' value='4'/>
       <enumerator name='GNUTLS_CRD_IA' value='5'/>
     </enum-decl>
-    <enum-decl name='gnutls_psk_key_flags' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='2595' column='1' hash='ec9c286850994608' id='type-id-206'>
+    <enum-decl name='gnutls_psk_key_flags' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='2595' column='1' hash='ec9c286850994608' id='type-id-208'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='GNUTLS_PSK_KEY_RAW' value='0'/>
       <enumerator name='GNUTLS_PSK_KEY_HEX' value='1'/>
       <enumerator name='GNUTLS_PSK_KEY_EXT' value='2'/>
     </enum-decl>
-    <enum-decl name='gnutls_server_name_type_t' naming-typedef-id='type-id-207' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='1628' column='1' hash='c8633d71e0b702a6' id='type-id-208'>
+    <enum-decl name='gnutls_server_name_type_t' naming-typedef-id='type-id-209' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='1628' column='1' hash='c8633d71e0b702a6' id='type-id-210'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='GNUTLS_NAME_DNS' value='1'/>
     </enum-decl>
-    <enum-decl name='gnutls_x509_crt_fmt_t' naming-typedef-id='type-id-209' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='856' column='1' hash='2a90723ab146748b' id='type-id-210'>
+    <enum-decl name='gnutls_x509_crt_fmt_t' naming-typedef-id='type-id-211' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='856' column='1' hash='2a90723ab146748b' id='type-id-212'>
       <underlying-type type-id='type-id-77'/>
       <enumerator name='GNUTLS_X509_FMT_DER' value='0'/>
       <enumerator name='GNUTLS_X509_FMT_PEM' value='1'/>
     </enum-decl>
-    <class-decl name='__pthread_internal_list' is-struct='yes' visibility='default' size-in-bits='128' filepath='/usr/include/bits/thread-shared-types.h' line='51' column='1' hash='5bcfb7f1ab39fa47' id='type-id-211'>
+    <class-decl name='__pthread_internal_list' is-struct='yes' visibility='default' size-in-bits='128' filepath='/usr/include/bits/thread-shared-types.h' line='51' column='1' hash='5bcfb7f1ab39fa47' id='type-id-213'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-212' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='53' column='1'/>
+        <var-decl name='__prev' type-id='type-id-214' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-212' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='54' column='1'/>
+        <var-decl name='__next' type-id='type-id-214' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='54' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__pthread_mutex_s' is-struct='yes' visibility='default' size-in-bits='320' filepath='/usr/include/bits/struct_mutex.h' line='22' column='1' hash='765d7e157ef2ec37' id='type-id-213'>
+    <class-decl name='__pthread_mutex_s' is-struct='yes' visibility='default' size-in-bits='320' filepath='/usr/include/bits/struct_mutex.h' line='22' column='1' hash='765d7e157ef2ec37' id='type-id-215'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__lock' type-id='type-id-11' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='24' column='1'/>
       </data-member>
@@ -1738,10 +1754,10 @@
         <var-decl name='__elision' type-id='type-id-188' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-214' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='36' column='1'/>
+        <var-decl name='__list' type-id='type-id-216' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='36' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='gnutls_datum_t' is-struct='yes' naming-typedef-id='type-id-215' visibility='default' size-in-bits='128' filepath='/usr/include/gnutls/gnutls.h' line='1291' column='1' hash='bb81b3b569018715' id='type-id-216'>
+    <class-decl name='gnutls_datum_t' is-struct='yes' naming-typedef-id='type-id-217' visibility='default' size-in-bits='128' filepath='/usr/include/gnutls/gnutls.h' line='1291' column='1' hash='bb81b3b569018715' id='type-id-218'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='data' type-id='type-id-186' visibility='default' filepath='/usr/include/gnutls/gnutls.h' line='1292' column='1'/>
       </data-member>
@@ -1749,21 +1765,22 @@
         <var-decl name='size' type-id='type-id-47' visibility='default' filepath='/usr/include/gnutls/gnutls.h' line='1293' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-211' size-in-bits='128' filepath='/usr/include/bits/thread-shared-types.h' line='55' column='1' id='type-id-214'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-213' size-in-bits='128' filepath='/usr/include/bits/thread-shared-types.h' line='55' column='1' id='type-id-216'/>
     <typedef-decl name='gnutls_alert_description_t' type-id='type-id-201' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='648' column='1' hash='e194d6870a33c76f' id='type-id-200'/>
     <typedef-decl name='gnutls_certificate_type_t' type-id='type-id-203' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='847' column='1' hash='0b0e0e9affa9ae45' id='type-id-202'/>
-    <typedef-decl name='gnutls_certificate_verify_function' type-id='type-id-217' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='1868' column='1' id='type-id-218'/>
-    <typedef-decl name='gnutls_credentials_type_t' type-id='type-id-205' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='293' column='1' hash='7be2a490e9a7a839' id='type-id-204'/>
-    <typedef-decl name='gnutls_datum_t' type-id='type-id-216' size-in-bits='128' filepath='/usr/include/gnutls/gnutls.h' line='1294' column='1' id='type-id-215'/>
-    <typedef-decl name='gnutls_free_function' type-id='type-id-219' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='2300' column='1' hash='fd7a63c0c6c822c4' id='type-id-220'/>
-    <typedef-decl name='gnutls_psk_key_flags' type-id='type-id-206' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='2599' column='1' hash='ec9c286850994608' id='type-id-221'/>
-    <typedef-decl name='gnutls_server_name_type_t' type-id='type-id-208' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='1630' column='1' hash='c8633d71e0b702a6' id='type-id-207'/>
-    <typedef-decl name='gnutls_x509_crt_fmt_t' type-id='type-id-210' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='859' column='1' hash='2a90723ab146748b' id='type-id-209'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-222' size-in-bits='320' filepath='/usr/include/bits/pthreadtypes.h' line='72' column='1' id='type-id-223'/>
-    <typedef-decl name='pthread_mutexattr_t' type-id='type-id-224' size-in-bits='32' filepath='/usr/include/bits/pthreadtypes.h' line='36' column='1' id='type-id-225'/>
-    <union-decl name='pthread_mutex_t' naming-typedef-id='type-id-223' visibility='default' size-in-bits='320' filepath='/usr/include/bits/pthreadtypes.h' line='67' column='1' hash='8e3e5ddbcaed875f' id='type-id-222'>
+    <typedef-decl name='gnutls_certificate_verify_function' type-id='type-id-219' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='1868' column='1' id='type-id-220'/>
+    <typedef-decl name='gnutls_close_request_t' type-id='type-id-205' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='794' column='1' hash='66c82e28899d26fa' id='type-id-204'/>
+    <typedef-decl name='gnutls_credentials_type_t' type-id='type-id-207' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='293' column='1' hash='7be2a490e9a7a839' id='type-id-206'/>
+    <typedef-decl name='gnutls_datum_t' type-id='type-id-218' size-in-bits='128' filepath='/usr/include/gnutls/gnutls.h' line='1294' column='1' id='type-id-217'/>
+    <typedef-decl name='gnutls_free_function' type-id='type-id-221' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='2300' column='1' hash='fd7a63c0c6c822c4' id='type-id-222'/>
+    <typedef-decl name='gnutls_psk_key_flags' type-id='type-id-208' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='2599' column='1' hash='ec9c286850994608' id='type-id-223'/>
+    <typedef-decl name='gnutls_server_name_type_t' type-id='type-id-210' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='1630' column='1' hash='c8633d71e0b702a6' id='type-id-209'/>
+    <typedef-decl name='gnutls_x509_crt_fmt_t' type-id='type-id-212' size-in-bits='32' alignment-in-bits='32' filepath='/usr/include/gnutls/gnutls.h' line='859' column='1' hash='2a90723ab146748b' id='type-id-211'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-224' size-in-bits='320' filepath='/usr/include/bits/pthreadtypes.h' line='72' column='1' id='type-id-225'/>
+    <typedef-decl name='pthread_mutexattr_t' type-id='type-id-226' size-in-bits='32' filepath='/usr/include/bits/pthreadtypes.h' line='36' column='1' id='type-id-227'/>
+    <union-decl name='pthread_mutex_t' naming-typedef-id='type-id-225' visibility='default' size-in-bits='320' filepath='/usr/include/bits/pthreadtypes.h' line='67' column='1' hash='8e3e5ddbcaed875f' id='type-id-224'>
       <data-member access='public'>
-        <var-decl name='__data' type-id='type-id-213' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='69' column='1'/>
+        <var-decl name='__data' type-id='type-id-215' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='69' column='1'/>
       </data-member>
       <data-member access='public'>
         <var-decl name='__size' type-id='type-id-197' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='70' column='1'/>
@@ -1772,7 +1789,7 @@
         <var-decl name='__align' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='71' column='1'/>
       </data-member>
     </union-decl>
-    <union-decl name='pthread_mutexattr_t' naming-typedef-id='type-id-225' visibility='default' size-in-bits='32' filepath='/usr/include/bits/pthreadtypes.h' line='32' column='1' hash='9efcb016ff95e817' id='type-id-224'>
+    <union-decl name='pthread_mutexattr_t' naming-typedef-id='type-id-227' visibility='default' size-in-bits='32' filepath='/usr/include/bits/pthreadtypes.h' line='32' column='1' hash='9efcb016ff95e817' id='type-id-226'>
       <data-member access='public'>
         <var-decl name='__size' type-id='type-id-199' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='34' column='1'/>
       </data-member>
@@ -1780,60 +1797,65 @@
         <var-decl name='__align' type-id='type-id-11' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='35' column='1'/>
       </data-member>
     </union-decl>
-    <pointer-type-def type-id='type-id-211' size-in-bits='64' hash='b83eb2deac70d470' id='type-id-212'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' hash='cea1d4b0943594a3' id='type-id-226'/>
-    <qualified-type-def type-id='type-id-215' const='yes' hash='5a80acf2d0fea502' id='type-id-227'/>
-    <pointer-type-def type-id='type-id-227' size-in-bits='64' hash='4064e3b112d2436b' id='type-id-228'/>
-    <qualified-type-def type-id='type-id-225' const='yes' hash='c2459df9f244e03e' id='type-id-229'/>
-    <pointer-type-def type-id='type-id-229' size-in-bits='64' hash='27684f07d936e645' id='type-id-230'/>
-    <pointer-type-def type-id='type-id-218' size-in-bits='64' hash='642bec7be6092e76' id='type-id-231'/>
-    <pointer-type-def type-id='type-id-215' size-in-bits='64' hash='4c6f5948093ff053' id='type-id-232'/>
-    <pointer-type-def type-id='type-id-223' size-in-bits='64' hash='8f341987365c3f23' id='type-id-233'/>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' hash='fd7a63c0c6c822c4' id='type-id-219'/>
-    <pointer-type-def type-id='type-id-234' size-in-bits='64' id='type-id-235'/>
+    <pointer-type-def type-id='type-id-213' size-in-bits='64' hash='b83eb2deac70d470' id='type-id-214'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' hash='cea1d4b0943594a3' id='type-id-228'/>
+    <qualified-type-def type-id='type-id-217' const='yes' hash='5a80acf2d0fea502' id='type-id-229'/>
+    <pointer-type-def type-id='type-id-229' size-in-bits='64' hash='4064e3b112d2436b' id='type-id-230'/>
+    <qualified-type-def type-id='type-id-227' const='yes' hash='c2459df9f244e03e' id='type-id-231'/>
+    <pointer-type-def type-id='type-id-231' size-in-bits='64' hash='27684f07d936e645' id='type-id-232'/>
+    <pointer-type-def type-id='type-id-220' size-in-bits='64' hash='642bec7be6092e76' id='type-id-233'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' hash='4c6f5948093ff053' id='type-id-234'/>
+    <pointer-type-def type-id='type-id-225' size-in-bits='64' hash='8f341987365c3f23' id='type-id-235'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' hash='fd7a63c0c6c822c4' id='type-id-221'/>
     <pointer-type-def type-id='type-id-236' size-in-bits='64' id='type-id-237'/>
     <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-239'/>
     <pointer-type-def type-id='type-id-240' size-in-bits='64' id='type-id-241'/>
     <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-243'/>
     <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-245'/>
-    <class-decl name='gnutls_certificate_credentials_st' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-234'/>
-    <class-decl name='gnutls_psk_client_credentials_st' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-238'/>
-    <class-decl name='gnutls_session_int' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-242'/>
-    <function-decl name='rc_tls_fd' mangled-name='rc_tls_fd' filepath='/home/nmav/projects/radcli/lib/tls.c' line='447' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_tls_fd@@RADCLI_10' hash='b6704dc70a55ac3c'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='500' column='1'/>
+    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-247'/>
+    <class-decl name='gnutls_certificate_credentials_st' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-236'/>
+    <class-decl name='gnutls_psk_client_credentials_st' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-240'/>
+    <class-decl name='gnutls_session_int' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-244'/>
+    <function-decl name='rc_tls_fd' mangled-name='rc_tls_fd' filepath='/home/nmav/projects/radcli/lib/tls.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_tls_fd@@RADCLI_10' hash='b6704dc70a55ac3c'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='519' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='rc_check_tls' mangled-name='rc_check_tls' filepath='/home/nmav/projects/radcli/lib/tls.c' line='478' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_check_tls@@RADCLI_10' hash='b6704dc70a55ac3c'>
-      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='500' column='1'/>
+    <function-decl name='rc_check_tls' mangled-name='rc_check_tls' filepath='/home/nmav/projects/radcli/lib/tls.c' line='493' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_check_tls@@RADCLI_10' hash='b6704dc70a55ac3c'>
+      <parameter type-id='type-id-130' name='rh' filepath='/home/nmav/projects/radcli/lib/config.c' line='519' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_dtls_set_timeouts' filepath='/usr/include/gnutls/dtls.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_dtls_set_timeouts' hash='0389e499374a3f97'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-47'/>
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <typedef-decl name='gnutls_session_t' type-id='type-id-243' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='1279' column='1' id='type-id-244'/>
+    <typedef-decl name='gnutls_session_t' type-id='type-id-245' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='1279' column='1' id='type-id-246'/>
     <function-decl name='gnutls_init' filepath='/usr/include/gnutls/gnutls.h' line='1315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_init' hash='6668baab5275d4c5'>
-      <parameter type-id='type-id-245'/>
+      <parameter type-id='type-id-247'/>
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_deinit' filepath='/usr/include/gnutls/gnutls.h' line='1316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_deinit' hash='7f32ffea222edbe7'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-4'/>
     </function-decl>
+    <function-decl name='gnutls_bye' filepath='/usr/include/gnutls/gnutls.h' line='1319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_bye' hash='9e6f687ba3f286ef'>
+      <parameter type-id='type-id-246'/>
+      <parameter type-id='type-id-204'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
     <function-decl name='gnutls_handshake' filepath='/usr/include/gnutls/gnutls.h' line='1321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_handshake' hash='388da3fa973fde78'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_handshake_set_timeout' filepath='/usr/include/gnutls/gnutls.h' line='1327' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_handshake_set_timeout' hash='2bb88322482ae81c'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='gnutls_alert_get' filepath='/usr/include/gnutls/gnutls.h' line='1335' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_alert_get' hash='392ddd37575e20d5'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-200'/>
     </function-decl>
     <function-decl name='gnutls_alert_get_name' filepath='/usr/include/gnutls/gnutls.h' line='1339' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_alert_get_name' hash='154b5031065dfc5f'>
@@ -1841,7 +1863,7 @@
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='gnutls_certificate_type_get' filepath='/usr/include/gnutls/gnutls.h' line='1370' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_type_get' hash='1b2bdb637dcf0fd4'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-202'/>
     </function-decl>
     <function-decl name='gnutls_error_is_fatal' filepath='/usr/include/gnutls/gnutls.h' line='1497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_error_is_fatal' hash='d628501fd2223339'>
@@ -1853,165 +1875,165 @@
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='gnutls_heartbeat_ping' filepath='/usr/include/gnutls/gnutls.h' line='1519' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_heartbeat_ping' hash='64b268c2afc86ade'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-55'/>
       <parameter type-id='type-id-47'/>
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_record_send' filepath='/usr/include/gnutls/gnutls.h' line='1548' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_record_send' hash='c013aa17bfe204e4'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-3'/>
       <parameter type-id='type-id-55'/>
       <return type-id='type-id-117'/>
     </function-decl>
     <function-decl name='gnutls_record_recv' filepath='/usr/include/gnutls/gnutls.h' line='1557' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_record_recv' hash='c013aa17bfe204e4'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-3'/>
       <parameter type-id='type-id-55'/>
       <return type-id='type-id-117'/>
     </function-decl>
     <function-decl name='gnutls_server_name_set' filepath='/usr/include/gnutls/gnutls.h' line='1632' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_server_name_set' hash='3cf77f0af9b7637f'>
-      <parameter type-id='type-id-244'/>
-      <parameter type-id='type-id-207'/>
+      <parameter type-id='type-id-246'/>
+      <parameter type-id='type-id-209'/>
       <parameter type-id='type-id-3'/>
       <parameter type-id='type-id-55'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_heartbeat_enable' filepath='/usr/include/gnutls/gnutls.h' line='1649' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_heartbeat_enable' hash='2bb88322482ae81c'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='gnutls_priority_set_direct' filepath='/usr/include/gnutls/gnutls.h' line='1808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_priority_set_direct' hash='881d31261d7717c8'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-226'/>
+      <parameter type-id='type-id-228'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_set_default_priority' filepath='/usr/include/gnutls/gnutls.h' line='1834' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_set_default_priority' hash='388da3fa973fde78'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_credentials_set' filepath='/usr/include/gnutls/gnutls.h' line='2019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_credentials_set' hash='d5d85d8c61c04744'>
-      <parameter type-id='type-id-244'/>
-      <parameter type-id='type-id-204'/>
+      <parameter type-id='type-id-246'/>
+      <parameter type-id='type-id-206'/>
       <parameter type-id='type-id-3'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <typedef-decl name='gnutls_certificate_credentials_t' type-id='type-id-235' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='2052' column='1' id='type-id-236'/>
+    <typedef-decl name='gnutls_certificate_credentials_t' type-id='type-id-237' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='2052' column='1' id='type-id-238'/>
     <function-decl name='gnutls_certificate_free_credentials' filepath='/usr/include/gnutls/gnutls.h' line='2081' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_free_credentials' hash='7f32ffea222edbe7'>
-      <parameter type-id='type-id-236'/>
+      <parameter type-id='type-id-238'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='gnutls_certificate_allocate_credentials' filepath='/usr/include/gnutls/gnutls.h' line='2082' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_allocate_credentials' hash='388da3fa973fde78'>
-      <parameter type-id='type-id-237'/>
+      <parameter type-id='type-id-239'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_certificate_set_x509_trust_file' filepath='/usr/include/gnutls/gnutls.h' line='2137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_set_x509_trust_file' hash='b5123cd0f9c430fe'>
-      <parameter type-id='type-id-236'/>
+      <parameter type-id='type-id-238'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-209'/>
+      <parameter type-id='type-id-211'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_certificate_set_x509_key_file' filepath='/usr/include/gnutls/gnutls.h' line='2155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_set_x509_key_file' hash='42d85191e9454b9d'>
-      <parameter type-id='type-id-236'/>
+      <parameter type-id='type-id-238'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-209'/>
+      <parameter type-id='type-id-211'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <var-decl name='gnutls_free' type-id='type-id-220' visibility='default' filepath='/usr/include/gnutls/gnutls.h' line='2309' column='1' elf-symbol-id='gnutls_free'/>
+    <var-decl name='gnutls_free' type-id='type-id-222' visibility='default' filepath='/usr/include/gnutls/gnutls.h' line='2309' column='1' elf-symbol-id='gnutls_free'/>
     <function-decl name='gnutls_transport_set_int2' filepath='/usr/include/gnutls/gnutls.h' line='2407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_transport_set_int2' hash='d628501fd2223339'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-11'/>
       <parameter type-id='type-id-11'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='gnutls_session_set_ptr' filepath='/usr/include/gnutls/gnutls.h' line='2441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_session_set_ptr' hash='7f32ffea222edbe7'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-3'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='gnutls_session_get_ptr' filepath='/usr/include/gnutls/gnutls.h' line='2442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_session_get_ptr' hash='7f32ffea222edbe7'>
-      <parameter type-id='type-id-244'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <typedef-decl name='gnutls_psk_client_credentials_t' type-id='type-id-239' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='2585' column='1' id='type-id-240'/>
+    <typedef-decl name='gnutls_psk_client_credentials_t' type-id='type-id-241' size-in-bits='64' filepath='/usr/include/gnutls/gnutls.h' line='2585' column='1' id='type-id-242'/>
     <function-decl name='gnutls_psk_free_client_credentials' filepath='/usr/include/gnutls/gnutls.h' line='2601' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_psk_free_client_credentials' hash='7f32ffea222edbe7'>
-      <parameter type-id='type-id-240'/>
+      <parameter type-id='type-id-242'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='gnutls_psk_allocate_client_credentials' filepath='/usr/include/gnutls/gnutls.h' line='2602' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_psk_allocate_client_credentials' hash='388da3fa973fde78'>
-      <parameter type-id='type-id-241'/>
+      <parameter type-id='type-id-243'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='gnutls_psk_set_client_credentials' filepath='/usr/include/gnutls/gnutls.h' line='2606' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_psk_set_client_credentials' hash='625f70f9fc878b8a'>
-      <parameter type-id='type-id-240'/>
+      <parameter type-id='type-id-242'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-228'/>
-      <parameter type-id='type-id-221'/>
+      <parameter type-id='type-id-230'/>
+      <parameter type-id='type-id-223'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='gnutls_certificate_set_verify_function' filepath='/usr/include/gnutls/gnutls.h' line='2802' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_set_verify_function' hash='aa9f0d16bd44ff10'>
-      <parameter type-id='type-id-236'/>
-      <parameter type-id='type-id-231'/>
+    <function-decl name='gnutls_certificate_set_verify_function' filepath='/usr/include/gnutls/gnutls.h' line='2804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_set_verify_function' hash='aa9f0d16bd44ff10'>
+      <parameter type-id='type-id-238'/>
+      <parameter type-id='type-id-233'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='gnutls_certificate_verify_peers2' filepath='/usr/include/gnutls/gnutls.h' line='2822' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_verify_peers2' hash='cd648ea08204a733'>
-      <parameter type-id='type-id-244'/>
+    <function-decl name='gnutls_certificate_verify_peers2' filepath='/usr/include/gnutls/gnutls.h' line='2824' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_verify_peers2' hash='cd648ea08204a733'>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-48'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='gnutls_certificate_verify_peers3' filepath='/usr/include/gnutls/gnutls.h' line='2824' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_verify_peers3' hash='bb41a3ada991dc33'>
-      <parameter type-id='type-id-244'/>
+    <function-decl name='gnutls_certificate_verify_peers3' filepath='/usr/include/gnutls/gnutls.h' line='2826' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_verify_peers3' hash='bb41a3ada991dc33'>
+      <parameter type-id='type-id-246'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-48'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='gnutls_certificate_verification_status_print' filepath='/usr/include/gnutls/gnutls.h' line='2833' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_verification_status_print' hash='fa2b6a117920810f'>
+    <function-decl name='gnutls_certificate_verification_status_print' filepath='/usr/include/gnutls/gnutls.h' line='2835' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gnutls_certificate_verification_status_print' hash='fa2b6a117920810f'>
       <parameter type-id='type-id-47'/>
       <parameter type-id='type-id-202'/>
-      <parameter type-id='type-id-232'/>
+      <parameter type-id='type-id-234'/>
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pthread_mutex_init' hash='f616842fe991fad1'>
-      <parameter type-id='type-id-233'/>
-      <parameter type-id='type-id-230'/>
+      <parameter type-id='type-id-235'/>
+      <parameter type-id='type-id-232'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='786' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pthread_mutex_destroy' hash='0e581935b984ff36'>
-      <parameter type-id='type-id-233'/>
+      <parameter type-id='type-id-235'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='794' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pthread_mutex_lock' hash='0e581935b984ff36'>
-      <parameter type-id='type-id-233'/>
+      <parameter type-id='type-id-235'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='835' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pthread_mutex_unlock' hash='0e581935b984ff36'>
-      <parameter type-id='type-id-233'/>
+      <parameter type-id='type-id-235'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-type size-in-bits='64' hash='388da3fa973fde78' id='type-id-217'>
-      <parameter type-id='type-id-244'/>
+    <function-type size-in-bits='64' hash='388da3fa973fde78' id='type-id-219'>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-11'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='util.c' comp-dir-path='/home/nmav/projects/radcli/lib' language='LANG_C11'>
-    <class-decl name='timespec' is-struct='yes' visibility='default' size-in-bits='128' filepath='/usr/include/bits/types/struct_timespec.h' line='11' column='1' hash='7451f9a3207df4f1' id='type-id-246'>
+    <class-decl name='timespec' is-struct='yes' visibility='default' size-in-bits='128' filepath='/usr/include/bits/types/struct_timespec.h' line='11' column='1' hash='7451f9a3207df4f1' id='type-id-248'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tv_sec' type-id='type-id-19' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='16' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-247' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='21' column='1'/>
+        <var-decl name='tv_nsec' type-id='type-id-249' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='21' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__clockid_t' type-id='type-id-11' size-in-bits='32' filepath='/usr/include/bits/types.h' line='169' column='1' hash='09d17c08f594edc7' id='type-id-248'/>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-12' size-in-bits='64' filepath='/usr/include/bits/types.h' line='197' column='1' hash='b119fe0931d2ee10' id='type-id-247'/>
-    <typedef-decl name='clockid_t' type-id='type-id-248' size-in-bits='32' filepath='/usr/include/bits/types/clockid_t.h' line='7' column='1' hash='09d17c08f594edc7' id='type-id-249'/>
-    <pointer-type-def type-id='type-id-246' size-in-bits='64' hash='abfdebaa4180c5b7' id='type-id-250'/>
-    <function-decl name='rc_mksid' mangled-name='rc_mksid' filepath='/home/nmav/projects/radcli/lib/util.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_mksid@@RADCLI_10' hash='02a096d257a5e00d'>
+    <typedef-decl name='__clockid_t' type-id='type-id-11' size-in-bits='32' filepath='/usr/include/bits/types.h' line='169' column='1' hash='09d17c08f594edc7' id='type-id-250'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-12' size-in-bits='64' filepath='/usr/include/bits/types.h' line='197' column='1' hash='b119fe0931d2ee10' id='type-id-249'/>
+    <typedef-decl name='clockid_t' type-id='type-id-250' size-in-bits='32' filepath='/usr/include/bits/types/clockid_t.h' line='7' column='1' hash='09d17c08f594edc7' id='type-id-251'/>
+    <pointer-type-def type-id='type-id-248' size-in-bits='64' hash='abfdebaa4180c5b7' id='type-id-252'/>
+    <function-decl name='rc_mksid' mangled-name='rc_mksid' filepath='/home/nmav/projects/radcli/lib/util.c' line='103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='rc_mksid@@RADCLI_10' hash='02a096d257a5e00d'>
       <return type-id='type-id-30'/>
     </function-decl>
     <function-decl name='setns' filepath='/usr/include/bits/sched.h' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='setns' hash='a9fd86e6e981c3b5'>
@@ -2026,8 +2048,8 @@
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='clock_gettime' filepath='/usr/include/time.h' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='clock_gettime' hash='abb4abf77092cad6'>
-      <parameter type-id='type-id-249'/>
-      <parameter type-id='type-id-250'/>
+      <parameter type-id='type-id-251'/>
+      <parameter type-id='type-id-252'/>
       <return type-id='type-id-11'/>
     </function-decl>
   </abi-instr>

--- a/doc/radius-test-server.md
+++ b/doc/radius-test-server.md
@@ -1,24 +1,46 @@
 # RADIUS test server (`tests/radius-server.py`)
 
 A minimal RADIUS server written in Python 3 (stdlib only) used by the test suite
-to craft responses that a real server such as FreeRADIUS would not produce.
-Currently used by `tests/msg-auth-tests.sh` to test Message-Authenticator handling.
+to craft responses that a real server such as FreeRADIUS would not produce, and
+to exercise client behavior (delivery, non-blocking sends) without root or a
+real `radiusd`/`freeradius` in `PATH`. Currently used by:
+
+- `tests/msg-auth-tests.sh` — Message-Authenticator handling (Access-Request/Accept)
+- `tests/acct-async-tests.sh` — `rc_acct_async()` delivery and non-blocking return
+  (Accounting-Request/Response, `--no-reply`)
 
 ## Invocation
 
 ```
 python3 tests/radius-server.py [--port PORT] [--secret SECRET] \
-                               [--msg-auth correct|absent|wrong]
+                               [--msg-auth correct|absent|wrong] [--no-reply]
 ```
 
 | Option | Default | Meaning |
 |--------|---------|---------|
 | `--port` | 1812 | UDP port to listen on |
 | `--secret` | `testing123` | Shared secret (must match the client config) |
-| `--msg-auth` | `correct` | How to handle the Message-Authenticator attribute in the reply |
+| `--msg-auth` | `correct` | How to handle the Message-Authenticator attribute in an Access-Accept reply (ignored for Accounting-Request) |
+| `--no-reply` | off | Log every received Access-/Accounting-Request but send no response (UDP transport only) |
 
-The server accepts one UDP packet at a time, sends one reply, and loops forever.
-It exits when killed (SIGTERM/SIGKILL).
+The server accepts one UDP packet at a time and, unless `--no-reply` is given,
+sends one reply, looping forever. It exits when killed (SIGTERM/SIGKILL). Every
+recognized request (Access-Request or Accounting-Request) is logged to stdout
+as `radius-server: received <Access-Request|Accounting-Request> id=<N>` as soon
+as it's parsed — regardless of `--no-reply` — so a test can grep the server's
+captured output to prove a packet was actually delivered, not just that the
+client returned successfully.
+
+### Accounting-Request handling
+
+An Accounting-Request (code 4) gets an empty Accounting-Response (code 5) with
+a correctly computed Response Authenticator — `--msg-auth` does not apply, since
+Message-Authenticator enforcement is Access-only (`REQ-NET-SEC-008`). Combined
+with `--no-reply`, this lets a test model an accounting server that receives
+requests but never (or slowly) answers, to verify a client's non-blocking send
+path — see `tests/acct-async-tests.sh` for how it drives two such servers to
+verify both that `rc_acct_async()` returns promptly and that every configured
+server was actually reached.
 
 ---
 
@@ -214,6 +236,12 @@ in `handle_packet`.
 
 **New `--msg-auth` mode**: add a choice to the `argparse` definition and a
 corresponding branch after the `packet` assembly in `handle_packet`.
+
+**Model a non-responsive or slow server**: use `--no-reply` (`handle_packet`
+returns `None` right after logging receipt, before building any response) to
+test a client's non-blocking/fire-and-forget path, or add a `time.sleep()`
+before the `sock.sendto()` in `run()` to test a slow-but-eventually-replying
+server instead.
 
 **Inspect the incoming request**: the raw request bytes are in `data`; the
 attributes start at `data[20:]` and can be walked with a `while` loop reading

--- a/doc/requirements/attrs.md
+++ b/doc/requirements/attrs.md
@@ -365,12 +365,15 @@ it.
 *or* `request_type != PW_ACCOUNTING_REQUEST`, and the `"acctserver"` list
 otherwise (plain accounting request over UDP/TCP), then forward to
 `rc_aaa_ctx_server()`. It MUST return `ERROR_RC` if the selected list is
-empty/unconfigured (`rc_conf_srv()` returns `NULL`).
+empty/unconfigured (`rc_conf_srv()` returns `NULL`). This selection logic is
+factored into the internal helper `rc_select_aaa_server()`, shared verbatim
+by `rc_aaa_ctx()` and `rc_acct_async()` (`REQ-ATTR-NET-030`) — both MUST
+apply the identical authserver/acctserver rule, not divergent copies.
 **Strength:** MUST
 **Status:** DERIVED
-**Source:** lib/buildreq.c:83-104
+**Source:** lib/buildreq.c:69-85 (`rc_select_aaa_server`), lib/buildreq.c:166-179 (`rc_aaa_ctx`)
 **Acceptance:** [NET] unit, local — with `so_type == RC_SOCKET_TLS`, an accounting-type request still selects `authserver`; with `so_type == RC_SOCKET_UDP`, it selects `acctserver`; with no `acctserver` configured, `rc_acct()` returns `ERROR_RC` before any packet is built.
-**Links:** REQ-NET-* (transport type / TLS-DTLS shared-port behavior, net.md)
+**Links:** REQ-NET-* (transport type / TLS-DTLS shared-port behavior, net.md), REQ-ATTR-NET-030
 
 ### REQ-ATTR-NET-023 — rc_aaa_ctx_server auto-fills NAS-Port and seeds Acct-Delay-Time before its retry loop
 
@@ -383,12 +386,14 @@ the creation time as `start_time` if absent, or, if the caller already
 supplied one, computing `start_time` by subtracting the *existing* pair's
 value from the current time so that later delay computation is consistent
 whether or not the caller pre-seeded the field. Both happen once, before the
-per-server retry loop begins.
+per-server retry loop begins. This fill logic is factored into the internal
+helper `rc_fill_acct_pairs()`, shared verbatim by `rc_aaa_ctx_server()` and
+`rc_aaa_ctx_server_async()` (`REQ-ATTR-NET-030`).
 **Strength:** MUST
 **Status:** DERIVED
-**Source:** lib/buildreq.c:150-177
+**Source:** lib/buildreq.c:102-140 (`rc_fill_acct_pairs`), lib/buildreq.c:222-224 (call site in `rc_aaa_ctx_server`)
 **Acceptance:** [NET] unit, local — an accounting request with no `PW_NAS_PORT`/`PW_ACCT_DELAY_TIME` gets both added; one with a caller-supplied `PW_NAS_PORT` keeps the caller's value; one with a caller-supplied non-zero `PW_ACCT_DELAY_TIME` does not get a second such pair added.
-**Links:** REQ-ATTR-NET-024
+**Links:** REQ-ATTR-NET-024, REQ-ATTR-NET-030
 
 ### REQ-ATTR-NET-024 — Acct-Delay-Time is recomputed on every retransmission attempt
 
@@ -491,6 +496,40 @@ bound the write to a smaller caller buffer.
 **Source:** include/radcli/radcli.h:70 (`PW_MAX_MSG_SIZE`), 655-667 (declarations); lib/buildreq.c:76, 123, 226, 248, 270, 318 (Doxygen `@param msg` notes: "must point to a buffer of PW_MAX_MSG_SIZE bytes"); all `msg` parameters passed through unchanged to `rc_send_server`/`rc_send_server_ctx`
 **Acceptance:** [NET][SEC] code-review — every call site passing a non-NULL `msg` allocates it as `char msg[PW_MAX_MSG_SIZE]` or equivalent; flagged as a precondition, not independently enforced by this document's functions (no length is passed in, so a too-small buffer cannot be detected here — see `net.md` for the write itself).
 **Links:** REQ-NET-* (msg write, net.md)
+
+### REQ-ATTR-NET-030 — rc_acct_async addresses every configured accounting server unconditionally, without waiting for or judging any reply
+
+**Requirement:** `rc_acct_async()` MUST select the server list via
+`rc_select_aaa_server()` (the same authserver/acctserver rule as
+`REQ-ATTR-NET-022`) and MUST return `ERROR_RC` if none is configured. It
+MUST then fill `PW_NAS_PORT`/`PW_ACCT_DELAY_TIME` via `rc_fill_acct_pairs()`
+(`REQ-ATTR-NET-023`, with `add_nas_port` fixed at `1`) and, for *every*
+index in `aaaserver->name[]`/`port[]`/`secret[]` in order, recompute
+`Acct-Delay-Time` (`REQ-ATTR-NET-024`'s per-attempt recompute rule) and call
+`rc_buildreq()` + `rc_send_server_ctx(..., no_wait=1)` — the fire-and-forget
+mode of `REQ-NET-NET-017`. Unlike `rc_aaa_ctx_server()` (`REQ-ATTR-NET-025`),
+it MUST NOT stop after the first successful send: every configured server is
+contacted regardless of the per-server result, since a `no_wait` send has no
+reply to distinguish "delivered" from "accepted." It MUST count a server as
+reached only when the per-server result is `OK_RC` (per `REQ-NET-NET-017`,
+`no_wait` never yields `TIMEOUT_RC`), and MUST return `OK_RC` overall if at
+least one server was reached, `ERROR_RC` only if every server's send failed
+outright.
+**Strength:** MUST
+**Status:** DERIVED
+**Source:** lib/buildreq.c:373-420 (`rc_aaa_ctx_server_async`), lib/buildreq.c:440-449
+(`rc_acct_async`)
+**Acceptance:** [NET] unit, local — a 2-server `acctserver` list with the first
+unreachable and the second reachable yields `OK_RC` and the second server MUST still be
+contacted even though it comes after the first send returned a terminal state; a config
+with no `acctserver` (and no TLS/DTLS `authserver` fallback trigger) returns `ERROR_RC`
+before any packet is built. `tests/acct-async-tests.sh` — end-to-end via
+`src/radiusclient -A`, asserting completion in well under `radius_timeout` against an
+unreachable first server, i.e. no blocking failover wait (contrast with
+`REQ-ATTR-NET-025`'s blocking failover for `rc_acct()`).
+**Links:** REQ-ATTR-NET-022, REQ-ATTR-NET-023, REQ-ATTR-NET-024, REQ-ATTR-NET-025 (the
+blocking counterpart this deliberately does not follow), REQ-NET-NET-017 (net.md; the
+`timeout=0` transport contract this depends on)
 
 ---
 

--- a/doc/requirements/net.md
+++ b/doc/requirements/net.md
@@ -300,6 +300,35 @@ found), enforcement of this requirement is code-review only.
 `init_session()` call goes through this path), REQ-NET-TEARDOWN-004 (the same `tmps`/
 `restart_session()` pairing — covers failure-path safety, not initial-state correctness)
 
+### REQ-NET-NET-017 — `rc_send_server_ctx()`'s `no_wait` parameter is an explicit fire-and-forget mode: transmit once and return `OK_RC` without waiting for a reply, never `TIMEOUT_RC`
+
+**Requirement:** `rc_send_server_ctx()` (internal-only: declared in `include/includes.h`, not
+`include/radcli/radcli.h`/`lib/radcli.map.in`, so its signature carries no ABI obligation) takes
+an explicit `int no_wait` parameter rather than inferring fire-and-forget mode from
+`data->timeout == 0`. When `no_wait` is non-zero, immediately after the single `sendto()` call
+succeeds the function MUST close the socket, capture the request's own secret/vector into `*ctx`
+if non-NULL (`populate_ctx()`, mirroring the normal path's teardown obligations —
+`REQ-NET-TEARDOWN-001`, `REQ-NET-SEC-009`), and return `OK_RC` — it MUST NOT enter the
+`poll()`/retry-budget loop (`REQ-NET-NET-009`) at all, and MUST NOT consult or require any
+particular value of `data->timeout`/`data->retries`. Because the retry/poll loop that produces
+`TIMEOUT_RC` is structurally unreachable when `no_wait` is set, `TIMEOUT_RC` MUST NOT be returned
+under `no_wait` — the only observable outcomes are `OK_RC` (send succeeded) or a send-failure code
+(`ERROR_RC`/`NETUNREACH_RC`), preserving `REQ-NET-ERR-001`'s single, unconditional meaning for
+`TIMEOUT_RC` everywhere else in the function.
+**Strength:** MUST
+**Status:** DERIVED
+**Source:** lib/sendserver.c:423-424 (`no_wait` parameter), lib/sendserver.c:696-708 (early
+`SCLOSE`/`populate_ctx`/`OK_RC` branch, taken before the retry/poll loop at 710-736 that produces
+`TIMEOUT_RC`); lib/buildreq.c:392-411 (`rc_aaa_ctx_server_async()` calling `rc_send_server_ctx(rh,
+NULL, &data, NULL, type, 1)` and treating only `OK_RC` as per-server success)
+**Acceptance:** [NET] unit, local — calling `rc_send_server_ctx()` with `no_wait=1` against an
+unreachable server returns `OK_RC` (not `TIMEOUT_RC`) without a `poll()` call blocking
+(measurable: wall-clock duration of the call is well under any nonzero timeout value), regardless
+of the `data->timeout`/`data->retries` values passed; `tests/acct-async-tests.sh` exercises this
+end-to-end via `rc_acct_async()`, asserting completion in well under `radius_timeout`.
+**Links:** REQ-NET-NET-009, REQ-NET-ERR-001, REQ-ATTR-NET-030 (attrs.md; the `rc_acct_async()`
+caller contract)
+
 ---
 
 ## SEC — Message-Authenticator, Response Authenticator, TLS/DTLS credential handling
@@ -595,6 +624,8 @@ callers.
 **Acceptance:** [ERR] code-review — every `return`/`goto cleanup` path in
 `rc_send_server_ctx()` assigns `result` from the enumerated set before falling through to
 `return result`.
+**Links:** REQ-NET-NET-017 (the `no_wait` fire-and-forget mode holds to this same contract,
+without exception — `no_wait` never produces `TIMEOUT_RC`)
 
 ### REQ-NET-ERR-002 — A reply whose declared RADIUS length is outside [20, 4096] is rejected before any further parsing
 

--- a/include/includes.h
+++ b/include/includes.h
@@ -210,6 +210,6 @@ struct rc_aaa_ctx_st
 };
 
 int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data,
-                        char *msg, rc_type type);
+                        char *msg, rc_type type, int no_wait);
 
 #endif

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -592,6 +592,11 @@ typedef struct rc_aaa_ctx_st RC_AAA_CTX;
  * file (@c tls-ca-file, @c tls-cert-file, @c tls-key-file).  See radexample.c
  * for a complete compilable example.
  *
+ * For accounting requests that must not block (e.g. sending Accounting-Stop
+ * for open sessions while an application is shutting down), use
+ * rc_acct_async() instead of rc_acct(): it addresses every configured
+ * accounting server without waiting for a reply.
+ *
  * \section nofile_sec Operation without a config file
  *
  * Programmatic configuration (without a file) is also possible using
@@ -657,6 +662,27 @@ int rc_auth(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send,
 int rc_auth_proxy(rc_handle *rh, VALUE_PAIR *send, VALUE_PAIR **received, char *msg);
 int rc_acct(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send);
 int rc_acct_proxy(rc_handle *rh, VALUE_PAIR *send);
+
+/** Sends an accounting request to every configured accounting server without waiting for a reply
+ *
+ * Selects the server list the same way rc_acct() does (acctserver, or
+ * authserver under TLS/DTLS). Unlike rc_acct()/rc_aaa(), which stop at the
+ * first server that replies and fail over to the next only after a
+ * timeout, this sends to *every* configured server unconditionally, since
+ * there is no reply to judge success or failure by. Intended for
+ * best-effort notifications such as an Accounting-Stop sent while an
+ * application is shutting down and cannot afford to block.
+ *
+ * @param rh a handle to parsed configuration.
+ * @param client_port the physical NAS port number to include (may be zero).
+ * @param send VALUE_PAIR list of attributes to send; NAS-Port and
+ *  Acct-Delay-Time are filled in as with rc_acct().
+ * @return OK_RC (0) if the packet was handed to the socket layer for at
+ *  least one server, ERROR_RC if no accounting servers are configured or
+ *  the send failed for all of them.
+ */
+int rc_acct_async(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send);
+
 int rc_check(rc_handle *rh, char *host, char *secret, unsigned short port, char *msg);
 
 int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **received,

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -56,6 +56,89 @@ void rc_buildreq(rc_handle const *rh, SEND_DATA * data, int code, char *server,
 	data->code = code;
 }
 
+/** @brief Selects the server list and rc_type for a request based on transport and request type
+ *
+ * @note Internal helper shared by rc_aaa_ctx() and rc_acct_async().
+ *
+ * @param rh a handle to parsed configuration.
+ * @param aaaserver receives the selected SERVER list from configuration.
+ * @param type receives AUTH or ACCT, matching the selected server list.
+ * @param request_type one of the standard RADIUS codes (e.g., PW_ACCESS_REQUEST).
+ * @return OK_RC (0) on success, ERROR_RC if no matching servers are configured.
+ */
+static int rc_select_aaa_server(rc_handle *rh, SERVER **aaaserver,
+				rc_type *type, rc_standard_codes request_type)
+{
+	if (rh->so_type == RC_SOCKET_TLS || rh->so_type == RC_SOCKET_DTLS ||
+	    request_type != PW_ACCOUNTING_REQUEST) {
+		*aaaserver = rc_conf_srv(rh, "authserver");
+		*type = AUTH;
+	} else {
+		*aaaserver = rc_conf_srv(rh, "acctserver");
+		*type = ACCT;
+	}
+
+	if (*aaaserver == NULL)
+		return ERROR_RC;
+
+	return OK_RC;
+}
+
+/** @brief Fills in NAS-Port and Acct-Delay-Time on a request being built
+ *
+ * @note Internal helper shared by rc_aaa_ctx_server() and
+ * rc_aaa_ctx_server_async().
+ *
+ * @param rh a handle to parsed configuration.
+ * @param data the request being built; @c send_pairs is extended in place.
+ * @param nas_port the physical NAS port number to include (may be zero).
+ * @param add_nas_port if non-zero, PW_NAS_PORT is added to the sent pairs.
+ * @param request_type one of the standard RADIUS codes (e.g., PW_ACCESS_REQUEST).
+ * @param adt_vp receives the Acct-Delay-Time pair when @p request_type is
+ *  PW_ACCOUNTING_REQUEST, so the caller can update it on each retransmission.
+ * @param start_time receives the time the delay is measured from.
+ * @return OK_RC (0) on success, ERROR_RC on failure.
+ */
+static int rc_fill_acct_pairs(rc_handle const *rh, SEND_DATA *data,
+			      uint32_t nas_port, int add_nas_port,
+			      rc_standard_codes request_type,
+			      VALUE_PAIR **adt_vp, double *start_time)
+{
+	time_t dtime;
+	double now;
+
+	if (add_nas_port != 0
+	    && rc_avpair_get(data->send_pairs, PW_NAS_PORT, 0) == NULL) {
+		/*
+		 * Fill in NAS-Port
+		 */
+		if (rc_avpair_add(rh, &(data->send_pairs), PW_NAS_PORT,
+				  &nas_port, 0, 0) == NULL)
+			return ERROR_RC;
+	}
+
+	if (request_type == PW_ACCOUNTING_REQUEST) {
+		/*
+		 * Fill in Acct-Delay-Time
+		 */
+		dtime = 0;
+		now = rc_getmtime();
+		*adt_vp = rc_avpair_get(data->send_pairs, PW_ACCT_DELAY_TIME, 0);
+		if (*adt_vp == NULL) {
+			*adt_vp = rc_avpair_add(rh, &(data->send_pairs),
+					       PW_ACCT_DELAY_TIME, &dtime, 0,
+					       0);
+			if (*adt_vp == NULL)
+				return ERROR_RC;
+			*start_time = now;
+		} else {
+			*start_time = now - (*adt_vp)->lvalue;
+		}
+	}
+
+	return OK_RC;
+}
+
 /** @brief Builds an authentication/accounting request and submits it to a server, optionally returning context
  *
  * Selects the server list from configuration (authserver or acctserver
@@ -87,15 +170,7 @@ int rc_aaa_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, uint32_t nas_port,
 	SERVER *aaaserver;
 	rc_type type;
 
-	if (rh->so_type == RC_SOCKET_TLS || rh->so_type == RC_SOCKET_DTLS ||
-	    request_type != PW_ACCOUNTING_REQUEST) {
-		aaaserver = rc_conf_srv(rh, "authserver");
-		type = AUTH;
-	} else {
-		aaaserver = rc_conf_srv(rh, "acctserver");
-		type = ACCT;
-	}
-	if (aaaserver == NULL)
+	if (rc_select_aaa_server(rh, &aaaserver, &type, request_type) != OK_RC)
 		return ERROR_RC;
 
 	return rc_aaa_ctx_server(rh, ctx, aaaserver, type,
@@ -140,41 +215,15 @@ int rc_aaa_ctx_server(rc_handle * rh, RC_AAA_CTX ** ctx, SERVER * aaaserver,
 	int timeout = rc_conf_int(rh, "radius_timeout");
 	int retries = rc_conf_int(rh, "radius_retries");
 	double start_time = 0;
-	double now = 0;
 	time_t dtime;
 	int servernum;
 
 	data.send_pairs = send;
 	data.receive_pairs = NULL;
 
-	if (add_nas_port != 0
-	    && rc_avpair_get(data.send_pairs, PW_NAS_PORT, 0) == NULL) {
-		/*
-		 * Fill in NAS-Port
-		 */
-		if (rc_avpair_add(rh, &(data.send_pairs), PW_NAS_PORT,
-				  &nas_port, 0, 0) == NULL)
-			return ERROR_RC;
-	}
-
-	if (request_type == PW_ACCOUNTING_REQUEST) {
-		/*
-		 * Fill in Acct-Delay-Time
-		 */
-		dtime = 0;
-		now = rc_getmtime();
-		adt_vp = rc_avpair_get(data.send_pairs, PW_ACCT_DELAY_TIME, 0);
-		if (adt_vp == NULL) {
-			adt_vp = rc_avpair_add(rh, &(data.send_pairs),
-					       PW_ACCT_DELAY_TIME, &dtime, 0,
-					       0);
-			if (adt_vp == NULL)
-				return ERROR_RC;
-			start_time = now;
-		} else {
-			start_time = now - adt_vp->lvalue;
-		}
-	}
+	if (rc_fill_acct_pairs(rh, &data, nas_port, add_nas_port, request_type,
+			       &adt_vp, &start_time) != OK_RC)
+		return ERROR_RC;
 
 	if (data.receive_pairs != NULL) {
 		rc_avpair_free(data.receive_pairs);
@@ -192,7 +241,7 @@ int rc_aaa_ctx_server(rc_handle * rh, RC_AAA_CTX ** ctx, SERVER * aaaserver,
 			rc_avpair_assign(adt_vp, &dtime, 0);
 		}
 
-		result = rc_send_server_ctx(rh, ctx, &data, msg, type);
+		result = rc_send_server_ctx(rh, ctx, &data, msg, type, 0);
 
 		if ((result == OK_RC) || (result == CHALLENGE_RC) || (result == REJECT_RC)) {
 			if (request_type != PW_ACCOUNTING_REQUEST) {
@@ -307,6 +356,99 @@ int rc_acct_proxy(rc_handle * rh, VALUE_PAIR * send)
 {
 
 	return rc_aaa(rh, 0, send, NULL, NULL, 0, PW_ACCOUNTING_REQUEST);
+}
+
+/** @brief Sends an accounting request to every server in @p aaaserver without waiting for a reply
+ *
+ * @note Internal helper behind rc_acct_async().
+ *
+ * @param rh a handle to parsed configuration.
+ * @param aaaserver a non-NULL SERVER describing the target server(s).
+ * @param type AUTH or ACCT, selects the destination port.
+ * @param nas_port the physical NAS port number to include (may be zero).
+ * @param send VALUE_PAIR list of attributes to send.
+ * @return OK_RC (0) if the packet was handed to the socket layer for at
+ *  least one server, ERROR_RC on failure.
+ */
+static int rc_aaa_ctx_server_async(rc_handle * rh, SERVER * aaaserver,
+				   rc_type type, uint32_t nas_port,
+				   VALUE_PAIR * send)
+{
+	SEND_DATA data;
+	VALUE_PAIR *adt_vp = NULL;
+	double start_time = 0;
+	time_t dtime;
+	int timeout = rc_conf_int(rh, "radius_timeout");
+	int retries = rc_conf_int(rh, "radius_retries");
+	int servernum;
+	int result;
+	int sent = 0;
+
+	data.send_pairs = send;
+	data.receive_pairs = NULL;
+
+	if (rc_fill_acct_pairs(rh, &data, nas_port, 1, PW_ACCOUNTING_REQUEST,
+			       &adt_vp, &start_time) != OK_RC)
+		return ERROR_RC;
+
+	for (servernum = 0; servernum < aaaserver->max; servernum++) {
+		dtime = rc_getmtime() - start_time;
+		rc_avpair_assign(adt_vp, &dtime, 0);
+
+		/* timeout/retries are not consulted by rc_send_server_ctx()
+		 * when no_wait is set below; passed through unchanged only
+		 * so SEND_DATA/DEBUG output reflect the real configuration. */
+		rc_buildreq(rh, &data, PW_ACCOUNTING_REQUEST,
+			    aaaserver->name[servernum],
+			    aaaserver->port[servernum],
+			    aaaserver->secret[servernum], timeout, retries);
+
+		result = rc_send_server_ctx(rh, NULL, &data, NULL, type, 1);
+
+		if (data.receive_pairs != NULL) {
+			rc_avpair_free(data.receive_pairs);
+			data.receive_pairs = NULL;
+		}
+
+		if (result == OK_RC) {
+			sent++;
+		} else {
+			DEBUG(LOG_INFO,
+			      "rc_send_server_ctx returned error (%d) for server %u",
+			      result, servernum);
+		}
+	}
+
+	return sent > 0 ? OK_RC : ERROR_RC;
+}
+
+/** @brief Sends an accounting request to every configured accounting server without waiting for a reply
+ *
+ * Selects the server list the same way rc_acct() does (acctserver, or
+ * authserver under TLS/DTLS). Unlike rc_acct()/rc_aaa(), which stop at the
+ * first server that replies and fail over to the next only after a
+ * timeout, this sends to *every* configured server unconditionally, since
+ * there is no reply to judge success or failure by. Intended for
+ * best-effort notifications such as an Accounting-Stop sent while an
+ * application is shutting down and cannot afford to block.
+ *
+ * @param rh a handle to parsed configuration.
+ * @param nas_port the physical NAS port number to include (may be zero).
+ * @param send VALUE_PAIR list of attributes to send; NAS-Port and
+ *  Acct-Delay-Time are filled in as with rc_acct().
+ * @return OK_RC (0) if the packet was handed to the socket layer for at
+ *  least one server, ERROR_RC if no accounting servers are configured or
+ *  the send failed for all of them.
+ */
+int rc_acct_async(rc_handle * rh, uint32_t nas_port, VALUE_PAIR * send)
+{
+	SERVER *aaaserver;
+	rc_type type;
+
+	if (rc_select_aaa_server(rh, &aaaserver, &type, PW_ACCOUNTING_REQUEST) != OK_RC)
+		return ERROR_RC;
+
+	return rc_aaa_ctx_server_async(rh, aaaserver, type, nas_port, send);
 }
 
 /** @brief Asks the server hostname on the specified port for a status message

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,9 +2,9 @@
 # Interfaces changed/added/removed:   CURRENT++       REVISION=0
 # Interfaces added:                             AGE++
 # Interfaces removed:                           AGE=0
-v_current = 10
+v_current = 11
 v_revision = 0
-v_age = 0
+v_age = 1
 lib_soversion = (v_current - v_age).to_string()
 lib_fullversion = '@0@.@1@.@2@'.format(v_current - v_age, v_age, v_revision)
 

--- a/lib/radcli.map.in
+++ b/lib/radcli.map.in
@@ -25,6 +25,7 @@ RADCLI_@LIBMAJOR@
 	rc_auth_proxy;
 	rc_acct;
 	rc_acct_proxy;
+	rc_acct_async;
 	rc_check;
 	rc_aaa;
 	rc_aaa_ctx;

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -230,7 +230,7 @@ static int populate_ctx(RC_AAA_CTX ** ctx, char secret[MAX_SECRET_LENGTH + 1],
  */
 int rc_send_server(rc_handle * rh, SEND_DATA * data, char *msg, rc_type type)
 {
-	return rc_send_server_ctx(rh, NULL, data, msg, type);
+	return rc_send_server_ctx(rh, NULL, data, msg, type, 0);
 }
 
 /* Verify items in returned packet
@@ -407,16 +407,21 @@ static int validate_message_authenticator(const uint8_t *recv_buffer,
  *
  * @param rh a handle to parsed configuration
  * @param ctx if non-NULL it will contain the context of sent request; It must be released using rc_aaa_ctx_free().
- * @param data a pointer to a SEND_DATA structure
+ * @param data a pointer to a SEND_DATA structure.
  * @param msg must be an array of %PW_MAX_MSG_SIZE or NULL; will contain the concatenation of
  *	any %PW_REPLY_MESSAGE received.
  * @param type must be %AUTH or %ACCT
+ * @param no_wait if non-zero, the request is transmitted once and this
+ *  function returns OK_RC immediately without waiting for or expecting a
+ *  reply; @c data->timeout and @c data->retries are not consulted in that
+ *  case. Used by rc_acct_async() for best-effort, non-blocking
+ *  notifications. TIMEOUT_RC is never returned when @p no_wait is set.
  * @return OK_RC (0) on success, CHALLENGE_RC when an Access-Challenge
- *  response is received, TIMEOUT_RC on timeout REJECT_RC on access reject,
+ *  response is received, TIMEOUT_RC on timeout, REJECT_RC on access reject,
  *  or negative on failure as return value.
  */
 int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
-		       char *msg, rc_type type)
+		       char *msg, rc_type type, int no_wait)
 {
 	int sockfd = -1;
 	AUTH_HDR *auth, *recv_auth;
@@ -685,6 +690,21 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 			result = errno == ENETUNREACH ? NETUNREACH_RC : ERROR_RC;
 			rc_log(LOG_ERR, "%s: socket: %s", __FUNCTION__,
 			       strerror(errno));
+			goto cleanup;
+		}
+
+		if (no_wait) {
+			/* Fire-and-forget: no reply to wait for, so close the
+			 * socket and capture the request's own secret/vector
+			 * (REQ-NET-TEARDOWN-001, REQ-NET-SEC-009) right here,
+			 * instead of falling through to the receive/switch
+			 * path below that expects a parsed response. */
+			SCLOSE(sockfd);
+			result = populate_ctx(ctx, secret, vector);
+			memset(secret, '\0', sizeof(secret));
+			if (result != OK_RC)
+				goto cleanup;
+			result = OK_RC;
 			goto cleanup;
 		}
 

--- a/src/radiusclient.c
+++ b/src/radiusclient.c
@@ -42,7 +42,9 @@ static void
 usage(void)
 {
 
-    fprintf(stderr, "usage: radiusclient [-D] [-f config_file] [-p nas_port] [-i] [-e hex-bytes] [-s | [-a] a1=v1 [a2=v2[...[aN=vN]...]]]\n");
+    fprintf(stderr, "usage: radiusclient [-D] [-f config_file] [-p nas_port] [-i] [-e hex-bytes] [-s | [-a|-A] a1=v1 [a2=v2[...[aN=vN]...]]]\n");
+    fprintf(stderr, "       -a - Send an accounting request and wait for the reply.\n");
+    fprintf(stderr, "       -A - Send an accounting request to every configured server without waiting for a reply (rc_acct_async()).\n");
     fprintf(stderr, "       -e hex-bytes - Specify an EAP message with colon-separated hex bytes. Ex. -e 2:0:0:9:1:74:65:73:74\n");
     exit(1);
 }
@@ -67,7 +69,7 @@ main(int argc, char **argv)
 
     acct = 0;
     server = 0;
-    while ((ch = getopt(argc, argv, "Daf:p:sie:")) != -1) {
+    while ((ch = getopt(argc, argv, "DaAf:p:sie:")) != -1) {
         switch (ch) {
         case 'D':
           debug = 1;
@@ -82,6 +84,10 @@ main(int argc, char **argv)
 
         case 'a':
             acct = 1;
+            break;
+
+        case 'A':
+            acct = 2;
             break;
 
         case 's':
@@ -180,7 +186,9 @@ main(int argc, char **argv)
             theend = 1;
             if (cp != NULL && len > 0) {
                 if (firstline != 0) {
-                    if (len >= 4 && memcmp(cp, "ACCT", 4) == 0)
+                    if (len >= 10 && memcmp(cp, "ACCT-ASYNC", 10) == 0)
+                        acct = 2;
+                    else if (len >= 4 && memcmp(cp, "ACCT", 4) == 0)
                         acct = 1;
                     firstline = 0;
                     theend = 0;
@@ -247,8 +255,10 @@ process(void *rh, VALUE_PAIR *send, int acct, int nas_port, int send_info)
 	    }
 	    rc_aaa_ctx_free(ctx);
         }
-    } else {
+    } else if (acct == 1) {
         i = rc_acct(rh, nas_port, send);
+    } else {
+        i = rc_acct_async(rh, nas_port, send);
     }
 
     return (i == OK_RC) || (i == CHALLENGE_RC) ? 0 : 1;

--- a/tests/acct-async-tests.sh
+++ b/tests/acct-async-tests.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# Copyright (C) 2026 Nikos Mavrogiannopoulos
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "===== rc_acct_async() non-blocking accounting tests ====="
+echo " 1. Returns promptly, without waiting for any server to reply"
+echo " 2. Every configured accounting server is contacted (no early exit)"
+echo " 3. Fails with no server contacted when no acctserver is configured"
+echo "==========================================================="
+
+if ! python3 -c '' 2>/dev/null; then
+	echo "This test requires python3"
+	exit 77
+fi
+
+. ${srcdir}/common.sh
+
+PID=$$
+TMPFILE=tmp$$.out
+LOG1=radius-server1-$PID.log
+LOG2=radius-server2-$PID.log
+SRVPID1=""
+SRVPID2=""
+
+eval "$GETPORT"; PORT1=$PORT
+eval "$GETPORT"; PORT2=$PORT
+
+function finish {
+	test -n "${SRVPID1}" && kill ${SRVPID1} >/dev/null 2>&1
+	test -n "${SRVPID2}" && kill ${SRVPID2} >/dev/null 2>&1
+	rm -f $TMPFILE $LOG1 $LOG2
+	rm -f radiusclient-temp$PID.conf
+	rm -f radiusclient-noacct$PID.conf
+	rm -f servers-temp$PID
+}
+trap finish EXIT
+
+wait_for_server() {
+	local port="$1"
+	local i
+	for i in 1 2 3 4 5 6 7 8; do
+		check_if_port_in_use ${port} && return 0
+		sleep 0.5
+	done
+	return 1
+}
+
+# Two accounting servers that receive and log every packet but never reply --
+# models a server that is slow, unresponsive, or simply doesn't answer
+# Accounting-Requests. rc_acct_async() (REQ-NET-NET-017's no_wait contract,
+# REQ-ATTR-NET-030) must still return promptly and must still contact both,
+# rather than stopping after the first send like rc_acct()'s blocking
+# failover would (REQ-ATTR-NET-025).
+python3 ${srcdir}/radius-server.py --port ${PORT1} --secret testing123 --no-reply >$LOG1 2>&1 &
+SRVPID1=$!
+python3 ${srcdir}/radius-server.py --port ${PORT2} --secret testing123 --no-reply >$LOG2 2>&1 &
+SRVPID2=$!
+wait_for_server ${PORT1} || { echo "[ FAIL ] server 1 did not start"; exit 1; }
+wait_for_server ${PORT2} || { echo "[ FAIL ] server 2 did not start"; exit 1; }
+
+cat >radiusclient-temp$PID.conf <<EOF
+nas-identifier my-nas-id
+authserver  127.0.0.1:${PORT1}
+acctserver  127.0.0.1:${PORT1},127.0.0.1:${PORT2}
+servers     ./servers-temp$PID
+dictionary  ${srcdir}/../etc/dictionary
+default_realm
+radius_timeout  10
+radius_retries  3
+bindaddr    *
+EOF
+echo "127.0.0.1/127.0.0.1	testing123" >servers-temp$PID
+
+START=$(date +%s)
+${top_builddir}/src/radiusclient -D -f radiusclient-temp$PID.conf -A User-Name=test Acct-Status-Type=Start >$TMPFILE 2>&1
+RET=$?
+END=$(date +%s)
+ELAPSED=$((END - START))
+sed 's/^/         | /' $TMPFILE
+
+if test $RET != 0; then
+	echo "[ FAIL ] async accounting request returned exit code $RET (expected 0/OK_RC)"
+	exit 1
+fi
+
+# radius_timeout is 10s with 3 retries; a blocking failover call would take at
+# least that long against even one non-replying server. The async call must
+# return almost immediately regardless of how many servers are configured or
+# whether any of them reply.
+if test $ELAPSED -ge 5; then
+	echo "[ FAIL ] async accounting request took ${ELAPSED}s; expected well under radius_timeout"
+	exit 1
+fi
+
+# Every configured server must have been contacted (REQ-ATTR-NET-030: no
+# early exit on a per-server result, unlike rc_acct()'s failover).
+for log in $LOG1 $LOG2; do
+	if ! grep -q "received Accounting-Request" $log; then
+		echo "[ FAIL ] $log: accounting server never received the packet"
+		cat $log
+		exit 1
+	fi
+done
+
+echo "[  OK  ] async accounting request reached both configured servers in ${ELAPSED}s"
+
+# Negative case: no acctserver configured -> ERROR_RC, no server contacted
+# (REQ-ATTR-NET-030).
+cat >radiusclient-noacct$PID.conf <<EOF
+nas-identifier my-nas-id
+authserver  127.0.0.1:${PORT1}
+servers     ./servers-temp$PID
+dictionary  ${srcdir}/../etc/dictionary
+default_realm
+radius_timeout  10
+radius_retries  3
+bindaddr    *
+EOF
+
+${top_builddir}/src/radiusclient -D -f radiusclient-noacct$PID.conf -A User-Name=test Acct-Status-Type=Start >$TMPFILE 2>&1
+RET=$?
+sed 's/^/         | /' $TMPFILE
+
+if test $RET == 0; then
+	echo "[ FAIL ] async accounting request with no acctserver configured unexpectedly succeeded"
+	exit 1
+fi
+
+echo "[  OK  ] async accounting request with no acctserver configured correctly failed"
+
+exit 0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,8 +5,8 @@ test_env.set('top_builddir', meson.project_build_root())
 test_env.set('srcdir', meson.current_source_dir())
 
 shell_tests = [
-  'basic-tests.sh', 'ipv6-tests.sh', 'failover-tests.sh', 'tcp-tests.sh',
-  'eap-tests.sh', 'no-server-file-tests.sh', 'reject-tests.sh',
+  'basic-tests.sh', 'ipv6-tests.sh', 'failover-tests.sh', 'acct-async-tests.sh',
+  'tcp-tests.sh', 'eap-tests.sh', 'no-server-file-tests.sh', 'reject-tests.sh',
   'skip-unknown-vsa.sh', 'namespace-tests.sh', 'radembedded-tests.sh',
   'radembedded-dict-tests.sh', 'ipv6-non-temp-addr-tests.sh',
   'msg-auth-tests.sh', 'malformed-packet-tests.sh',

--- a/tests/radius-server.py
+++ b/tests/radius-server.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Minimal RADIUS server for testing Message-Authenticator handling.
+# Minimal RADIUS server for testing Message-Authenticator handling and
+# Accounting-Request delivery, without root or a real freeradius/radiusd.
 # Sends Access-Accept responses with configurable Message-Authenticator:
 #   correct  - valid HMAC-MD5 (per RFC 3579), placed first per BLAST RADIUS spec
 #   absent   - no Message-Authenticator attribute in the response
 #   wrong    - attribute present (first) but value is all-zeros (deliberately incorrect)
+# Accounting-Requests get an empty Accounting-Response (no Message-Authenticator
+# handling, per REQ-NET-SEC-008).
 #
 # Usage:
 #   python3 radius-server.py [--port 1812] [--secret testing123] \
-#                            [--msg-auth correct|absent|wrong]
+#                            [--msg-auth correct|absent|wrong] [--no-reply]
+#
+# --no-reply logs every received Access-/Accounting-Request (proving it was
+# delivered) but never sends a response -- used to test a client's
+# non-blocking/fire-and-forget path (see acct-async-tests.sh) without relying
+# on an unreachable-host timeout.
 #
 # --transport tls speaks RADIUS/TLS (RFC 6614) instead of plain UDP: the same
 # Access-Accept packet bytes are framed over a TLS-wrapped TCP stream instead
@@ -26,8 +34,10 @@ import ssl
 import struct
 
 # RADIUS codes
-ACCESS_REQUEST = 1
-ACCESS_ACCEPT  = 2
+ACCESS_REQUEST      = 1
+ACCESS_ACCEPT       = 2
+ACCOUNTING_REQUEST  = 4
+ACCOUNTING_RESPONSE = 5
 
 # Attribute types
 ATTR_SERVICE_TYPE        = 6   # value 2 = Framed-User
@@ -122,10 +132,13 @@ def compute_hmac_md5(packet, secret):
     """HMAC-MD5 over the full packet (MA value must already be zeroed)."""
     return hmac.new(secret.encode(), packet, hashlib.md5).digest()
 
-def handle_packet(data, secret, msg_auth_mode, attrs_mode='normal'):
+def handle_packet(data, secret, msg_auth_mode, attrs_mode='normal', no_reply=False):
     """
-    Parse an Access-Request and build an Access-Accept response.
-    Returns the response bytes, or None if the packet is not an Access-Request.
+    Parse an Access-Request or Accounting-Request and build the matching
+    reply. Returns the response bytes, or None if the packet's code is not
+    recognized or --no-reply was requested (the packet is still logged as
+    received either way -- see the print() below -- it is simply not
+    answered, e.g. to test a non-blocking/fire-and-forget client path).
     """
     if len(data) < 20:
         return None
@@ -133,8 +146,22 @@ def handle_packet(data, secret, msg_auth_mode, attrs_mode='normal'):
     code, ident, _pkt_len = struct.unpack('!BBH', data[:4])
     req_auth = data[4:20]
 
-    if code != ACCESS_REQUEST:
+    if code not in (ACCESS_REQUEST, ACCOUNTING_REQUEST):
         return None
+
+    code_name = 'Access-Request' if code == ACCESS_REQUEST else 'Accounting-Request'
+    print(f"radius-server: received {code_name} id={ident}", flush=True)
+
+    if no_reply:
+        return None
+
+    if code == ACCOUNTING_REQUEST:
+        # No Message-Authenticator handling for accounting (REQ-NET-SEC-008);
+        # an empty Accounting-Response is enough to exercise the reply path.
+        total_len = 20
+        resp_auth = compute_response_authenticator(
+            ACCOUNTING_RESPONSE, ident, total_len, req_auth, b'', secret)
+        return struct.pack('!BBH', ACCOUNTING_RESPONSE, ident, total_len) + resp_auth
 
     # Build attribute payload.  Per draft-ietf-radext-deprecating-radius,
     # Message-Authenticator MUST be the first attribute in the response.
@@ -179,16 +206,16 @@ def handle_packet(data, secret, msg_auth_mode, attrs_mode='normal'):
 
     return packet
 
-def run(port, secret, msg_auth_mode, attrs_mode='normal'):
+def run(port, secret, msg_auth_mode, attrs_mode='normal', no_reply=False):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(('0.0.0.0', port))
-    print(f"radius-server: listening on port {port}, msg-auth={msg_auth_mode}, attrs={attrs_mode}",
-          flush=True)
+    print(f"radius-server: listening on port {port}, msg-auth={msg_auth_mode}, "
+          f"attrs={attrs_mode}, no-reply={no_reply}", flush=True)
 
     while True:
         data, addr = sock.recvfrom(4096)
-        response = handle_packet(data, secret, msg_auth_mode, attrs_mode)
+        response = handle_packet(data, secret, msg_auth_mode, attrs_mode, no_reply)
         if response is not None:
             sock.sendto(response, addr)
 
@@ -271,14 +298,20 @@ def main():
     parser.add_argument('--transport', choices=['udp', 'tls'], default='udp')
     parser.add_argument('--tls-cert', help='PEM certificate file (required for --transport tls)')
     parser.add_argument('--tls-key', help='PEM private key file (required for --transport tls)')
+    parser.add_argument('--no-reply', action='store_true',
+                        help='Log each received Access-/Accounting-Request but send no response '
+                             '(models a slow/unresponsive accounting server for testing a '
+                             'non-blocking client path). UDP transport only.')
     args = parser.parse_args()
 
     if args.transport == 'tls':
         if not args.tls_cert or not args.tls_key:
             parser.error('--transport tls requires --tls-cert and --tls-key')
+        if args.no_reply:
+            parser.error('--no-reply is only supported with --transport udp')
         run_tls(args.port, args.secret, args.msg_auth, args.tls_cert, args.tls_key, args.attrs)
     else:
-        run(args.port, args.secret, args.msg_auth, args.attrs)
+        run(args.port, args.secret, args.msg_auth, args.attrs, args.no_reply)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
RADIUS clients that must notify accounting servers, (e.g. an Accounting-Stop for every open session) cannot afford to block on rc_acct()'s wait-for-reply/failover semantics, nor do they care about a response at that point.

rc_acct_async() allows sending to every configured accounting server unconditionally, without waiting for any reply, and formalizes the timeout=0 "fire and forget" behavior as a documented contract.