### PR TITLE
lib/sendserver.c: scope BLAST RADIUS mitigation to RADIUS/UDP and RADIUS/TCP

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,8 @@
 * Version 1.5.3 (unreleased)
+- Per draft-ietf-radext-deprecating-radius-10 Section 4, no longer require
+  or position-check the Message-Authenticator attribute in responses
+  received over RADIUS/TLS or RADIUS/DTLS; those transports are already
+  integrity-protected.
 - Fix TLS/DTLS server hostname verification being silently disabled
   whenever tls-verify-hostname was explicitly set to anything other
   than the literal string "no". This didn't affect the default config

--- a/doc/requirements/net.md
+++ b/doc/requirements/net.md
@@ -413,25 +413,37 @@ attribute presence via `rc_avpair_get`, not on `recv_auth->code`)
 Message-Authenticator computed with the wrong secret MUST be rejected (`ERROR_RC`), not passed
 through as `REJECT_RC`.
 
-### REQ-NET-SEC-007 — BLAST RADIUS mitigation: Message-Authenticator MUST be the first attribute in an Access-* reply, unless explicitly disabled
+### REQ-NET-SEC-007 — BLAST RADIUS mitigation: Message-Authenticator MUST be the first attribute in an Access-* reply over RADIUS/UDP and RADIUS/TCP, unless explicitly disabled; MUST NOT be enforced over RADIUS/TLS or RADIUS/DTLS
 
-**Requirement:** Per `draft-ietf-radext-deprecating-radius` (the BLAST RADIUS mitigation), for
-`AUTH`-type replies `rc_send_server_ctx()` MUST reject (`ERROR_RC`) a reply whose first attribute
-is not `PW_MESSAGE_AUTHENTICATOR` (or which has zero attributes), UNLESS the config option
+**Requirement:** Per `draft-ietf-radext-deprecating-radius-10` Section 4 (the BLAST RADIUS
+mitigation), for `AUTH`-type replies received over `RC_SOCKET_UDP`/`RC_SOCKET_TCP`,
+`rc_send_server_ctx()` MUST reject (`ERROR_RC`) a reply whose first attribute is not
+`PW_MESSAGE_AUTHENTICATOR` (or which has zero attributes), UNLESS the config option
 `require-message-authenticator` is explicitly set to `false`/`no`. This check MUST run whether or
 not a Message-Authenticator attribute was found anywhere else in the packet — a reply that
 carries a *valid* Message-Authenticator attribute in a later position is still rejected by
 default, because the MD5-prefix-collision attack BLAST RADIUS exploits works by prepending
-attacker-controlled bytes before a genuine, valid Message-Authenticator.
-**Strength:** MUST NOT (accept non-first or absent MA by default) ; MUST (enforce position,
-respect the opt-out)
+attacker-controlled bytes before a genuine, valid Message-Authenticator. Conversely, per the same
+Section 4 clause ("MUST NOT be applied to RADIUS/TLS or RADIUS/DTLS"), this presence/position
+enforcement and the `require-message-authenticator` opt-out MUST NOT be applied when
+`rh->so_type` is `RC_SOCKET_TLS` or `RC_SOCKET_DTLS` — those transports are already
+integrity-protected end-to-end, so the MD5-prefix attack this mitigation defends against is not
+reachable, and a reply missing or misordering Message-Authenticator MUST still be accepted
+(subject to `REQ-NET-SEC-006`'s opportunistic validation, which still applies to all transports).
+**Strength:** MUST NOT (accept non-first or absent MA by default, over UDP/TCP) ; MUST (enforce
+position over UDP/TCP, respect the opt-out) ; MUST NOT (enforce presence/position over TLS/DTLS)
 **Status:** DERIVED
-**Source:** lib/sendserver.c:862-891
-**Acceptance:** [SEC] negative, local — a reply with a valid Message-Authenticator attribute
-appended *after* another attribute MUST be rejected under default config, and accepted when
-`require-message-authenticator=false` is set. Per `REQ-GEN-TEST-003`, negative test mandatory.
-**Links:** REQ-GEN-TEST-003, REQ-CONFIG-* (`require-message-authenticator` option, see
-`config.md`)
+**Source:** lib/sendserver.c:862-897 (the `rh->so_type != RC_SOCKET_TLS && rh->so_type !=
+RC_SOCKET_DTLS` guard at 879 scopes the enforcement to UDP/TCP)
+**Acceptance:** [SEC] negative, local — over UDP/TCP, a reply with a valid Message-Authenticator
+attribute appended *after* another attribute MUST be rejected under default config, and accepted
+when `require-message-authenticator=false` is set. Per `REQ-GEN-TEST-003`, negative test
+mandatory. [SEC] positive, local — over TLS, a reply with Message-Authenticator absent, or present
+but not first, MUST be accepted (`OK_RC`) regardless of `require-message-authenticator`; a reply
+with a Message-Authenticator attribute present but cryptographically wrong MUST still be rejected
+(exercises `REQ-NET-SEC-006`, unaffected by this requirement's transport scoping).
+**Links:** REQ-GEN-TEST-003, REQ-NET-SEC-006, REQ-NET-NET-012 (`rh->so_type` is what this
+requirement branches on), REQ-CONFIG-* (`require-message-authenticator` option, see `config.md`)
 
 ### REQ-NET-SEC-008 — Message-Authenticator enforcement (REQ-NET-SEC-006/007) applies only to `AUTH`-type exchanges, not `ACCT`
 

--- a/lib/config.c
+++ b/lib/config.c
@@ -657,8 +657,10 @@ int rc_apply_config(rc_handle *rh)
  * **Security:**
  *  - @b require-message-authenticator: set to @c no to accept responses that
  *    lack the Message-Authenticator attribute.  Enabled by default per
- *    draft-ietf-radext-deprecating-radius (CVE-2024-3596 / BLAST RADIUS);
- *    only disable for legacy servers that predate RFC 3579.
+ *    draft-ietf-radext-deprecating-radius-10 (CVE-2024-3596 / BLAST RADIUS);
+ *    only disable for legacy servers that predate RFC 3579.  Has no effect
+ *    over RADIUS/TLS or RADIUS/DTLS, where this mitigation is never
+ *    enforced, per draft-ietf-radext-deprecating-radius-10 Section 4.
  *
  * **Tuning:**
  *  - @b radius_timeout: request timeout in seconds (integer, default 3).

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -870,17 +870,24 @@ int rc_send_server_ctx(rc_handle * rh, RC_AAA_CTX ** ctx, SEND_DATA * data,
 			}
 		}
 
-		/* Enforce BLAST RADIUS: MA must also be the first attribute. */
-		if (length == 0 ||
-		    recv_buffer[AUTH_HDR_LEN] != PW_MESSAGE_AUTHENTICATOR) {
-			p = rc_conf_str(rh, "require-message-authenticator");
-			if (p == NULL || (strcasecmp(p, "false") != 0 && strcasecmp(p, "no") != 0)) {
-				rc_log(LOG_ERR,
-				       "rc_send_server: recvfrom: %s:%d: required attribute Message-Authenticator is missing or not first",
-				       server_name, data->svc_port);
-				memset(secret, '\0', sizeof(secret));
-				result = ERROR_RC;
-				goto cleanup;
+		/* Enforce BLAST RADIUS: MA must also be the first attribute.
+		 * Per draft-ietf-radext-deprecating-radius-10 Section 4, this
+		 * mitigation MUST be applied to RADIUS/UDP and RADIUS/TCP, and
+		 * MUST NOT be applied to RADIUS/TLS or RADIUS/DTLS: those
+		 * transports are already integrity-protected end-to-end, so the
+		 * MD5-prefix collision this guards against isn't reachable. */
+		if (rh->so_type != RC_SOCKET_TLS && rh->so_type != RC_SOCKET_DTLS) {
+			if (length == 0 ||
+			    recv_buffer[AUTH_HDR_LEN] != PW_MESSAGE_AUTHENTICATOR) {
+				p = rc_conf_str(rh, "require-message-authenticator");
+				if (p == NULL || (strcasecmp(p, "false") != 0 && strcasecmp(p, "no") != 0)) {
+					rc_log(LOG_ERR,
+					       "rc_send_server: recvfrom: %s:%d: required attribute Message-Authenticator is missing or not first",
+					       server_name, data->svc_port);
+					memset(secret, '\0', sizeof(secret));
+					result = ERROR_RC;
+					goto cleanup;
+				}
 			}
 		}
 	}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,7 +13,7 @@ shell_tests = [
 ]
 
 if have_gnutls
-  shell_tests += ['tls-tests.sh', 'tls-verify-hostname-tests.sh', 'tls-idle-restart-tests.sh', 'close-notify-tests.sh']
+  shell_tests += ['tls-tests.sh', 'tls-verify-hostname-tests.sh', 'tls-msg-auth-tests.sh', 'tls-idle-restart-tests.sh', 'close-notify-tests.sh']
 
   tls_restart = executable('tls-restart', 'tls-restart.c',
     include_directories: tests_incdirs, link_with: libradcli_shared,

--- a/tests/tls-msg-auth-tests.sh
+++ b/tests/tls-msg-auth-tests.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# Copyright (C) 2026 Nikos Mavrogiannopoulos
+#
+# License: BSD
+#
+# draft-ietf-radext-deprecating-radius-10 Section 4 requires that the BLAST
+# RADIUS Message-Authenticator mitigations "MUST be applied to RADIUS/UDP
+# and RADIUS/TCP, and MUST NOT be applied to RADIUS/TLS or RADIUS/DTLS"
+# (those transports are already integrity-protected, so the MD5-prefix
+# attack the mitigation defends against isn't reachable). This mirrors
+# msg-auth-tests.sh, but over RADIUS/TLS, to confirm radcli does not
+# require or position-check Message-Authenticator there, while it still
+# opportunistically validates one if the server sends it (REQ-NET-SEC-006,
+# unaffected by the transport scoping of REQ-NET-SEC-007).
+#
+# DTLS is not separately covered here: rc_send_server_ctx() branches on
+# rh->so_type with a single `RC_SOCKET_TLS || RC_SOCKET_DTLS` check
+# (lib/sendserver.c), and DTLS shares that whole function with TLS -- only
+# rc_init_tls()'s flags argument differs between them. tests/radius-server.py
+# only implements a UDP and a TLS listener, so DTLS is exercised structurally
+# rather than with its own test server here.
+
+srcdir="${srcdir:-.}"
+
+echo "===== Message-Authenticator over RADIUS/TLS tests ====="
+echo " 1. Client accepts response missing the attr (not required over TLS)"
+echo " 2. Client accepts MA present but not first (not enforced over TLS)"
+echo " 3. Client rejects a present-but-wrong MA (opportunistic check still applies)"
+echo " 4. require-message-authenticator=no is a no-op over TLS (still accepts)"
+echo "========================================================="
+
+if ! python3 -c 'import ssl' 2>/dev/null; then
+	echo "This test requires python3 with the ssl module"
+	exit 77
+fi
+
+. ${srcdir}/common.sh
+
+PID=$$
+TMPFILE=tmp$$.out
+RADIUSPID=""
+
+function finish {
+	test -n "${RADIUSPID}" && kill ${RADIUSPID} >/dev/null 2>&1
+	rm -f $TMPFILE
+	rm -f radiusclient-temp$PID.conf
+	rm -f radiusclient-no-req$PID.conf
+	rm -f servers-temp$PID
+}
+trap finish EXIT
+
+wait_for_server() {
+	local i
+	for i in 1 2 3 4 5 6 7 8; do
+		check_if_port_in_use ${PORT} && return 0
+		sleep 0.5
+	done
+	return 1
+}
+
+# Build a radiusclient.conf pointing to localhost:PORT over TLS. The
+# configured secret is irrelevant -- RFC 6614 Section 3.4 fixes the
+# RADIUS/TLS shared secret to "radsec", which radcli enforces regardless of
+# what's in servers-temp$PID.
+make_conf() {
+	cat >radiusclient-temp$PID.conf <<EOF
+serv-type tls
+tls-ca-file ${srcdir}/dtls/ca.pem
+tls-verify-hostname false
+nas-identifier my-nas-id
+authserver  127.0.0.1:${PORT}
+acctserver  127.0.0.1:${PORT}
+servers     ./servers-temp$PID
+dictionary  ${srcdir}/../etc/dictionary
+default_realm
+radius_timeout  5
+radius_retries  1
+bindaddr    *
+EOF
+}
+
+# Each call picks a fresh port: a killed TLS/TCP server can leave its old
+# socket in TIME_WAIT, which would make check_if_port_in_use (netstat -an,
+# which matches any socket state, not just LISTEN) report the port as
+# already "in use" before the new server has actually bound it -- a race
+# that doesn't affect the UDP server in msg-auth-tests.sh, which has no
+# connection state to linger.
+start_server() {
+	eval "$GETPORT"
+	make_conf
+	python3 ${srcdir}/radius-server.py \
+		--transport tls --port ${PORT} --secret radsec --msg-auth "$1" \
+		--tls-cert ${srcdir}/raddb/cert-rsa.pem --tls-key ${srcdir}/raddb/key-rsa.pem \
+		2>/dev/null &
+	RADIUSPID=$!
+	wait_for_server
+}
+
+stop_server() {
+	if test -n "${RADIUSPID}"; then
+		kill ${RADIUSPID} >/dev/null 2>&1
+		wait ${RADIUSPID} 2>/dev/null
+		RADIUSPID=""
+	fi
+}
+
+echo "127.0.0.1	testing123" >servers-temp$PID
+
+# Test 1: server sends no Message-Authenticator; over UDP this would fail by
+# default (msg-auth-tests.sh test 1) -- over TLS it MUST succeed.
+start_server absent
+run_test "Accept response with absent MA over TLS" \
+	"${top_builddir}/src/radiusclient -D -i -f radiusclient-temp$PID.conf User-Name=test Password=test" \
+	|| exit 1
+
+grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0; then
+	echo "[ FAIL ] Expected Framed-Protocol = 'PPP' in response"
+	exit 1
+fi
+
+# Test 2: server sends a correct MA but not as the first attribute; over
+# UDP this would fail by default (msg-auth-tests.sh test 4) -- over TLS the
+# position requirement MUST NOT be enforced.
+stop_server
+start_server not-first
+run_test "Accept response with correct MA not first, over TLS" \
+	"${top_builddir}/src/radiusclient -D -i -f radiusclient-temp$PID.conf User-Name=test Password=test" \
+	|| exit 1
+
+# Test 3: server sends a Message-Authenticator with the wrong value. This is
+# not the BLAST presence/position mitigation -- it's plain opportunistic
+# validation (REQ-NET-SEC-006), which applies on every transport and MUST
+# still reject.
+stop_server
+start_server wrong
+run_test "Reject response with incorrect MA value over TLS" \
+	"${top_builddir}/src/radiusclient -D -i -f radiusclient-temp$PID.conf User-Name=test Password=test" \
+	expect_fail || exit 1
+
+# Test 4: require-message-authenticator=no explicitly set over TLS changes
+# nothing -- the presence/position check it would otherwise disable is
+# already not enforced over TLS.
+stop_server
+start_server absent
+cp radiusclient-temp$PID.conf radiusclient-no-req$PID.conf
+echo "require-message-authenticator	no" >> radiusclient-no-req$PID.conf
+
+run_test "Accept response with absent MA over TLS (require-message-authenticator=no)" \
+	"${top_builddir}/src/radiusclient -D -i -f radiusclient-no-req$PID.conf User-Name=test Password=test" \
+	|| exit 1
+stop_server
+
+echo ""
+exit 0


### PR DESCRIPTION
Per draft-ietf-radext-deprecating-radius-10 Section 4, the Message- Authenticator "MUST be first attribute" enforcement MUST be applied to RADIUS/UDP and RADIUS/TCP, and MUST NOT be applied to RADIUS/TLS or RADIUS/DTLS, since those transports are already integrity-protected and the MD5-prefix attack the mitigation defends against isn't reachable there. rc_send_server_ctx() enforced this unconditionally on every transport; gate it on rh->so_type instead.